### PR TITLE
Add partial support for phrase queries

### DIFF
--- a/core/src/test/scala/pink/cozydev/protosearch/MultiIndexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/MultiIndexSuite.scala
@@ -97,4 +97,19 @@ class MultiIndexSuite extends munit.FunSuite {
     assertEquals(books, Right(List(eggs)))
   }
 
+  test("single term phrase query (original casing)") {
+    val books = search("\"Eggs\"")
+    assertEquals(books, Right(List(eggs)))
+  }
+
+  test("single term phrase query") {
+    val books = search("\"eggs\"")
+    assertEquals(books, Right(List(eggs)))
+  }
+
+  test("multi term phrase query fails") {
+    val books = search("\"Green Eggs\"")
+    assert(books.isLeft)
+  }
+
 }


### PR DESCRIPTION
This will allow us to parse single term phrase queries
like `"cats"` or `name:"cats"`
but not `"JSON parsing"`