### PR TITLE
Search schema

### DIFF
--- a/core/src/main/scala/pink/cozydev/protosearch/MultiIndex.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/MultiIndex.scala
@@ -69,11 +69,11 @@ object MultiIndex {
 
   def apply[A](
       defaultField: String,
-      head: (String, A => String, Analyzer),
-      tail: (String, A => String, Analyzer)*
+      head: (String, (A => String, Analyzer)),
+      tail: (String, (A => String, Analyzer))*
   ): List[A] => MultiIndex = {
 
-    val bldrs = (head :: tail.toList).map { case (name, getter, tokenizer) =>
+    val bldrs = (head :: tail.toList).map { case (name, (getter, tokenizer)) =>
       Bldr(name, getter, tokenizer, ListBuffer.empty)
     }
 

--- a/core/src/main/scala/pink/cozydev/protosearch/MultiIndex.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/MultiIndex.scala
@@ -69,11 +69,11 @@ object MultiIndex {
 
   def apply[A](
       defaultField: String,
-      head: (String, (A => String, Analyzer)),
-      tail: (String, (A => String, Analyzer))*
+      head: (String, A => String, Analyzer),
+      tail: (String, A => String, Analyzer)*
   ): List[A] => MultiIndex = {
 
-    val bldrs = (head :: tail.toList).map { case (name, (getter, tokenizer)) =>
+    val bldrs = (head :: tail.toList).map { case (name, getter, tokenizer) =>
       Bldr(name, getter, tokenizer, ListBuffer.empty)
     }
 

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchSchema.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchSchema.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pink.cozydev.protosearch
 
 import pink.cozydev.protosearch.MultiIndex

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchSchema.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchSchema.scala
@@ -1,0 +1,40 @@
+package pink.cozydev.protosearch
+
+import pink.cozydev.protosearch.MultiIndex
+import pink.cozydev.protosearch.analysis.Analyzer
+import pink.cozydev.protosearch.analysis.QueryAnalyzer
+
+/**  For a type `A`, a SearchSchema describes the fields of the document representation
+  *  of `A`.
+  */
+case class SearchSchema[A] private (
+    private val schema: Map[String, (A => String, Analyzer)]
+) {
+  def queryAnalyzer(defaultField: String): QueryAnalyzer = {
+    val analyzers = schema.view.mapValues(_._2).toList
+    QueryAnalyzer(defaultField, analyzers.head, analyzers.tail: _*)
+  }
+
+  def indexBldr(defaultField: String): List[A] => MultiIndex = {
+    val ss = schema.toList
+    MultiIndex(defaultField, ss.head, ss.tail: _*)
+  }
+}
+object SearchSchema {
+  def apply[A](
+      head: (String, (A => String, Analyzer)),
+      tail: (String, (A => String, Analyzer))*
+  ): SearchSchema[A] =
+    new SearchSchema[A]((head :: tail.toList).toMap)
+}
+
+object Example {
+  case class Doc(title: String, author: String)
+
+  val analyzer = Analyzer.default
+
+  val s = SearchSchema[Doc](
+    "title" -> (_.title, analyzer),
+    "author" -> (_.author, analyzer),
+  )
+}

--- a/web/src/main/scala-3/pink/cozydev/protosearch/RepoSearch.scala
+++ b/web/src/main/scala-3/pink/cozydev/protosearch/RepoSearch.scala
@@ -125,10 +125,10 @@ object RepoSearch extends IOWebApp {
 
     val analyzer = Analyzer.default.withLowerCasing
     val searchSchema = SearchSchema[Repo](
-      "name" -> (_.name, analyzer),
-      "fullName" -> (_.fullName, analyzer),
-      "description" -> (_.description.getOrElse(""), analyzer),
-      "topics" -> (_.topics.mkString(" "), analyzer),
+      ("name", _.name, analyzer),
+      ("fullName", _.fullName, analyzer),
+      ("description", _.description.getOrElse(""), analyzer),
+      ("topics", _.topics.mkString(" "), analyzer),
     )
 
     def searchBldr(repos: List[Repo]): String => Either[String, List[Hit]] = {


### PR DESCRIPTION
This PR adds a minor new class `SearchSchema`

```scala
    val searchSchema = SearchSchema[Repo](
      ("name", _.name, analyzer),
      ("fullName", _.fullName, analyzer),
      ("description", _.description.getOrElse(""), analyzer),
      ("topics", _.topics.mkString(" "), analyzer),
    )
```

It allows search applications like RepoSearch to specify the mapping of field names to getters and analyzers only once.
This is a pretty minor addition that I'd like to keep tweaking, but I figured I'd keep the PRs small and moving instead.