### PR TITLE
Add support for rewriting last query term

### DIFF
--- a/core/src/main/scala/pink/cozydev/protosearch/LastTermRewrite.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/LastTermRewrite.scala
@@ -24,6 +24,7 @@ object LastTermRewrite {
   def termToPrefix(q: Query): Query =
     q match {
       case Query.TermQ(t) => Query.PrefixTerm(t)
+      case Query.FieldQ(fn, Query.TermQ(t)) => Query.FieldQ(fn, Query.PrefixTerm(t))
       case _ => q
     }
 

--- a/core/src/main/scala/pink/cozydev/protosearch/LastTermRewrite.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/LastTermRewrite.scala
@@ -18,13 +18,18 @@ package pink.cozydev.protosearch
 
 import cats.data.NonEmptyList
 import pink.cozydev.lucille.Query
+import pink.cozydev.lucille.Query.{TermQ, FieldQ, PrefixTerm, Group, OrQ}
 
 object LastTermRewrite {
 
   def termToPrefix(q: Query): Query =
     q match {
-      case Query.TermQ(t) => Query.PrefixTerm(t)
-      case Query.FieldQ(fn, Query.TermQ(t)) => Query.FieldQ(fn, Query.PrefixTerm(t))
+      case TermQ(t) =>
+        Group(NonEmptyList.one(OrQ(NonEmptyList.of(TermQ(t), PrefixTerm(t)))))
+      case FieldQ(fn, TermQ(t)) =>
+        Group(
+          NonEmptyList.one(OrQ(NonEmptyList.of(FieldQ(fn, TermQ(t)), FieldQ(fn, PrefixTerm(t)))))
+        )
       case _ => q
     }
 

--- a/core/src/main/scala/pink/cozydev/protosearch/LastTermRewrite.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/LastTermRewrite.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pink.cozydev.protosearch
+
+import cats.data.NonEmptyList
+import pink.cozydev.lucille.Query
+
+object LastTermRewrite {
+
+  def termToPrefix(q: Query): Query =
+    q match {
+      case Query.TermQ(t) => Query.PrefixTerm(t)
+      case _ => q
+    }
+
+  def lastTermPrefix(qs: NonEmptyList[Query]): NonEmptyList[Query] =
+    rewrite(qs, termToPrefix)
+
+  def rewrite(qs: NonEmptyList[Query], func: Query => Query): NonEmptyList[Query] =
+    if (qs.size == 0) qs
+    else if (qs.size == 1) NonEmptyList.one(func(qs.head))
+    else {
+      val newT = qs.tail.init :+ func(qs.last)
+      NonEmptyList(qs.head, newT)
+    }
+}

--- a/core/src/test/scala/pink/cozydev/protosearch/LastTermRewriteSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/LastTermRewriteSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pink.cozydev.protosearch
+
+import cats.data.NonEmptyList
+import pink.cozydev.lucille.Query.{TermQ, FieldQ, PrefixTerm, Group, OrQ}
+import pink.cozydev.protosearch.LastTermRewrite._
+
+class LastTermRewriteSuite extends munit.FunSuite {
+
+  test("termToPrefix rewrites termQ to termQ and prefix") {
+    val q = TermQ("f")
+    val expected =
+      Group(NonEmptyList.one(OrQ(NonEmptyList.of(TermQ("f"), PrefixTerm("f")))))
+    assertEquals(termToPrefix(q), expected)
+  }
+
+  test("termToPrefix rewrites fieldQ to fieldQ's with termQ and prefix") {
+    val q = FieldQ("fn", TermQ("c"))
+    val expected =
+      Group(
+        NonEmptyList.one(
+          OrQ(NonEmptyList.of(FieldQ("fn", TermQ("c")), FieldQ("fn", PrefixTerm("c"))))
+        )
+      )
+    assertEquals(termToPrefix(q), expected)
+  }
+
+  test("lastTermPrefix rewrites only the last termQ to termQ and prefix") {
+    val q =
+      NonEmptyList.of(TermQ("first"), TermQ("f"))
+    val expected =
+      NonEmptyList.of(
+        TermQ("first"),
+        Group(NonEmptyList.one(OrQ(NonEmptyList.of(TermQ("f"), PrefixTerm("f"))))),
+      )
+    assertEquals(lastTermPrefix(q), expected)
+  }
+}

--- a/web/src/main/scala-3/pink/cozydev/protosearch/RepoSearch.scala
+++ b/web/src/main/scala-3/pink/cozydev/protosearch/RepoSearch.scala
@@ -139,7 +139,7 @@ object RepoSearch extends IOWebApp {
       qs =>
         if (qs.isEmpty) Right(allHits)
         else {
-          val aq = qAnalyzer.parse(qs)
+          val aq = qAnalyzer.parse(qs).map(LastTermRewrite.lastTermPrefix)
           val results: Either[String, List[(Int, Double)]] =
             aq.flatMap(q => index.search(q).flatMap(ds => scorer.score(q, ds.toSet)))
           results.map(hits =>


### PR DESCRIPTION
Queries like `f` match `feral` and `name:c` matches cats.

<img width="713" alt="Screen Shot 2023-03-28 at 9 32 29 PM" src="https://user-images.githubusercontent.com/5440389/228403375-a4b3525b-7581-4e6e-8de9-3901bc59e665.png">


We keep the origin term query in a group query so that exact matches are scored higher:
<img width="992" alt="Screen Shot 2023-03-28 at 9 41 08 PM" src="https://user-images.githubusercontent.com/5440389/228404513-529e3505-223f-41ee-ad8e-ac871389fd1d.png">

Closes https://github.com/cozydev-pink/protosearch/issues/25
