### PR TITLE
Add more documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.10, 3.2.2]
-        java: [temurin@8]
+        java: [temurin@11]
         project: [rootJS, rootJVM]
     runs-on: ${{ matrix.os }}
     steps:
@@ -38,21 +38,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download Java (temurin@8)
-        id: download-java-temurin-8
-        if: matrix.java == 'temurin@8'
+      - name: Download Java (temurin@11)
+        id: download-java-temurin-11
+        if: matrix.java == 'temurin@11'
         uses: typelevel/download-java@v2
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
         uses: actions/setup-java@v3
         with:
           distribution: jdkfile
-          java-version: 8
-          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
+          java-version: 11
+          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
 
       - name: Cache sbt
         uses: actions/cache@v3
@@ -70,7 +70,7 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: scalaJSLink
@@ -81,11 +81,11 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
 
       - name: Check binary compatibility
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories
@@ -111,7 +111,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.2.2]
-        java: [temurin@8]
+        java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -119,21 +119,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download Java (temurin@8)
-        id: download-java-temurin-8
-        if: matrix.java == 'temurin@8'
+      - name: Download Java (temurin@11)
+        id: download-java-temurin-11
+        if: matrix.java == 'temurin@11'
         uses: typelevel/download-java@v2
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
         uses: actions/setup-java@v3
         with:
           distribution: jdkfile
-          java-version: 8
-          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
+          java-version: 11
+          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
 
       - name: Cache sbt
         uses: actions/cache@v3
@@ -207,7 +207,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.2.2]
-        java: [temurin@8]
+        java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -215,21 +215,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download Java (temurin@8)
-        id: download-java-temurin-8
-        if: matrix.java == 'temurin@8'
+      - name: Download Java (temurin@11)
+        id: download-java-temurin-11
+        if: matrix.java == 'temurin@11'
         uses: typelevel/download-java@v2
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
         uses: actions/setup-java@v3
         with:
           distribution: jdkfile
-          java-version: 8
-          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
+          java-version: 11
+          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
 
       - name: Cache sbt
         uses: actions/cache@v3

--- a/build.sbt
+++ b/build.sbt
@@ -109,6 +109,7 @@ import laika.helium.config.{IconLink, HeliumIcon}
 lazy val docs = project
   .in(file("site"))
   .enablePlugins(TypelevelSitePlugin)
+  .dependsOn(core.jvm, web)
   .settings(
     tlSiteRelatedProjects := Seq(
       "lucene" -> url("https://lucene.apache.org/"),

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,9 @@ ThisBuild / tlSitePublishBranch := Some("main")
 ThisBuild / resolvers +=
   "SonaType Snapshots".at("https://s01.oss.sonatype.org/content/repositories/snapshots/")
 
+// use JDK 11
+ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
+
 val Scala213 = "2.13.10"
 val Scala3 = "3.2.2"
 ThisBuild / crossScalaVersions := Seq(Scala213, Scala3)

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,0 +1,49 @@
+## Queries
+
+Protosearch supports queries using boolean logic and a variety of advanced term queries.
+
+Let's setup a collection of books to search over:
+
+```scala mdoc:silent
+case class Book(author: String, title: String)
+
+val books: List[Book] = List(
+  Book("Beatrix Potter", "The Tale of Peter Rabbit"),
+  Book("Beatrix Potter", "The Tale of Two Bad Mice"),
+  Book("Dr. Suess", "One Fish, Two Fish, Red Fish, Blue Fish"),
+  Book("Dr. Suess", "Green Eggs and Ham"),
+)
+```
+
+And now for a search function:
+
+@:callout(info)
+
+There's currently a lot of boilerplate involved in this setup which we hope to minimize in future updates.
+
+@:@
+
+```scala mdoc:silent
+import pink.cozydev.protosearch.SearchSchema
+import pink.cozydev.protosearch.analysis.{Analyzer, QueryAnalyzer}
+
+val analyzer = Analyzer.default.withLowerCasing
+val searchSchema = SearchSchema[Book](
+  ("author", (b: Book) => b.author, analyzer),
+  ("title", (b: Book) => b.title, analyzer),
+)
+
+val index = searchSchema.indexBldr("title")(books)
+val qAnalyzer = searchSchema.queryAnalyzer("title")
+
+def search(q: String): Either[String, List[Book]] =
+  qAnalyzer.parse(q)
+    .flatMap(q => index.search(q))
+    .map(hits => hits.map(i => books(i)))
+```
+
+And finally, a search!
+
+```scala mdoc
+search("fish")
+```

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,6 +1,8 @@
-## Queries
+# Queries
 
 Protosearch supports queries using boolean logic and a variety of advanced term queries.
+
+## Setup
 
 Let's setup a collection of books to search over:
 
@@ -15,17 +17,14 @@ val books: List[Book] = List(
 )
 ```
 
-And now for a search function:
-
-@:callout(info)
-
-There's currently a lot of boilerplate involved in this setup which we hope to minimize in future updates.
-
-@:@
+In order to index our domain type `Book`, we'll need a few things.
+An `Analyzer` to convert strings of text into tokens.
+A `SearchSchema` to convert from our `Book` type into multiple fields of text.
+And then to create the index itself with a default field:
 
 ```scala mdoc:silent
 import pink.cozydev.protosearch.SearchSchema
-import pink.cozydev.protosearch.analysis.{Analyzer, QueryAnalyzer}
+import pink.cozydev.protosearch.analysis.Analyzer
 
 val analyzer = Analyzer.default.withLowerCasing
 val searchSchema = SearchSchema[Book](
@@ -34,16 +33,113 @@ val searchSchema = SearchSchema[Book](
 )
 
 val index = searchSchema.indexBldr("title")(books)
+```
+
+Finally we'll then need a `search` function to test out.
+We use a `queryAnalyzer` with the same default field here to make sure our queries get the same analysis as our documents did at indexing time.
+
+
+```scala mdoc:silent
 val qAnalyzer = searchSchema.queryAnalyzer("title")
 
-def search(q: String): Either[String, List[Book]] =
+def search(q: String): List[Book] =
   qAnalyzer.parse(q)
     .flatMap(q => index.search(q))
     .map(hits => hits.map(i => books(i)))
+    .fold(_ => Nil, identity)
 ```
 
-And finally, a search!
+Now we can use our `search` function to explore some different query types!
+
+## Term Queries
+
+The following term queries represent some of the primitive operations on the term dictionary.
+In general they specify a way to match one or more terms, and then the query as a whole matches documents containing those terms.
+
+### Term Query
+
+The most basic query is a single term query.
+Only documents that contain the term will match.
 
 ```scala mdoc
 search("fish")
+```
+
+### Prefix Query
+
+A prefix query specifies all terms with a given prefix, and then matches all documents containing those terms.
+
+```scala mdoc
+search("egg*")
+```
+
+### Range Query
+
+A range query similarly specifies a range of terms, and then matches all documents containing those terms.
+
+```scala mdoc
+search("[fi TO gz]") // matching 'fish' and 'green'
+```
+
+### Phrase Query
+
+A phrase query is made up of one or more terms surrounded by double quotes, and matches documents containing those terms in exactly that order.
+
+```scala mdoc
+search("\"Red\"")
+```
+
+@:callout(warning)
+
+We do not yet support position data in the index and thus only support trivial one term phrase queries.
+
+@:@
+
+```scala mdoc
+search("\"Red Fish\"") // does not work yet
+```
+
+## Boolean Queries
+
+Boolean queries allow us combine multiple queries together with boolean logic, using the `OR`, `AND`, and `NOT` combinators.
+
+
+```scala mdoc
+search("fish OR ham")
+```
+
+```scala mdoc
+search("red AND blue")
+```
+
+```scala mdoc
+search("tale AND NOT mice")
+```
+
+## Group Query
+
+As queries get more complex, it can be helpful to group together parts with parenthesis.
+
+```scala mdoc
+search("(red OR blue OR green) AND (fish OR mice OR ham)")
+```
+
+
+## Field Query
+
+The field query allows a user to specify the unique field a query should match.
+Field queries work with term queries:
+
+```scala mdoc
+search("author:suess")
+```
+
+```scala mdoc
+search("author:beatri*")
+```
+
+Additionally, field queries can take more complex boolean queries if specified in a group:
+
+```scala mdoc
+search("author:([b TO e] AND NOT dr*)")
 ```

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -17,9 +17,10 @@ val books: List[Book] = List(
 )
 ```
 
-In order to index our domain type `Book`, we'll need a few things.
-An `Analyzer` to convert strings of text into tokens.
-A `SearchSchema` to convert from our `Book` type into multiple fields of text.
+In order to index our domain type `Book`, we'll need a few things:
+- An `Analyzer` to convert strings of text into tokens.
+- A `SearchSchema` to convert from our `Book` type into multiple fields of text.
+
 And then to create the index itself with a default field:
 
 ```scala mdoc:silent

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.19")
 addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % "0.4.19")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.0")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.7")


### PR DESCRIPTION
Adds a documentation page on the supported types of queries.

Also:
- explicitly specifies (and updates) our mdoc version
- update our build to use JDK11

Without these extra changes I had to build in two steps because old mdoc did not support latest scala 3:

1. `++3.2.2 web/fullOptJS`
2. `++2.13.10 docs/tlSitePreview`

Closes https://github.com/cozydev-pink/protosearch/issues/23