### PR TITLE
Readability tweaks, query reordering

### DIFF
--- a/core/src/main/scala/pink/cozydev/protosearch/BooleanRetrieval.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/BooleanRetrieval.scala
@@ -33,13 +33,7 @@ case class BooleanRetrieval(index: Index, defaultOR: Boolean = true) {
       case Query.TermQ(q) => Right(index.docsWithTermSet(q))
       case Query.PrefixTerm(p) => Right(index.docsForPrefix(p))
       case q: Query.RangeQ => rangeSearch(q)
-      case Query.PhraseQ(q) =>
-        // Optimistic phrase query handling
-        // In case the user added quotes to a single term
-        val resultSet = index.docsWithTermSet(q)
-        if (resultSet.nonEmpty) Right(resultSet)
-        else
-          Left(s"Phrase queries require position data, which we don't have yet. q: $q")
+      case q: Query.PhraseQ => phraseSearch(q)
       case Query.OrQ(qs) => qs.traverse(booleanModel).map(BooleanRetrieval.unionSets)
       case Query.AndQ(qs) => qs.traverse(booleanModel).map(BooleanRetrieval.intersectSets)
       case Query.NotQ(q) => booleanModel(q).map(matches => allDocs.removedAll(matches))
@@ -51,6 +45,14 @@ case class BooleanRetrieval(index: Index, defaultOR: Boolean = true) {
       case q: Query.ProximityQ => Left(s"Unsupported ProximityQ in BooleanRetrieval: $q")
       case q: Query.FuzzyTerm => Left(s"Unsupported FuzzyTerm in BooleanRetrieval: $q")
     }
+
+  private def phraseSearch(q: Query.PhraseQ): Either[String, Set[Int]] = {
+    // Optimistic phrase query handling for single term only
+    val resultSet = index.docsWithTermSet(q.q)
+    if (resultSet.nonEmpty) Right(resultSet)
+    else
+      Left(s"Phrase queries require position data, which we don't have yet. q: $q")
+  }
 
   private def rangeSearch(q: Query.RangeQ): Either[String, Set[Int]] =
     q match {

--- a/core/src/main/scala/pink/cozydev/protosearch/BooleanRetrieval.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/BooleanRetrieval.scala
@@ -28,7 +28,7 @@ case class BooleanRetrieval(index: Index, defaultOR: Boolean = true) {
     docs
   }
 
-  def booleanModel(q: Query): Either[String, Set[Int]] =
+  private def booleanModel(q: Query): Either[String, Set[Int]] =
     q match {
       case Query.TermQ(q) => Right(index.docsWithTermSet(q))
       case Query.PrefixTerm(p) => Right(index.docsForPrefix(p))

--- a/core/src/main/scala/pink/cozydev/protosearch/MultiIndex.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/MultiIndex.scala
@@ -40,12 +40,12 @@ case class MultiIndex(
 
   private lazy val allDocs: Set[Int] = Set.from(Range(0, defaultIndex.numDocs))
 
-  def booleanModel(q: Query): Either[String, Set[Int]] =
+  private def booleanModel(q: Query): Either[String, Set[Int]] =
     q match {
-      case Query.AndQ(qs) => qs.traverse(booleanModel).map(BooleanRetrieval.intersectSets)
       case Query.OrQ(qs) => qs.traverse(booleanModel).map(BooleanRetrieval.unionSets)
-      case Query.Group(qs) => qs.traverse(booleanModel).map(defaultCombine)
+      case Query.AndQ(qs) => qs.traverse(booleanModel).map(BooleanRetrieval.intersectSets)
       case Query.NotQ(q) => booleanModel(q).map(matches => allDocs.removedAll(matches))
+      case Query.Group(qs) => qs.traverse(booleanModel).map(defaultCombine)
       case Query.FieldQ(f, q) =>
         indexes.get(f).toRight(s"unsupported field $f").flatMap { index =>
           BooleanRetrieval(index, defaultOR).search(q)

--- a/core/src/main/scala/pink/cozydev/protosearch/Scorer.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/Scorer.scala
@@ -32,25 +32,8 @@ case class Scorer(index: MultiIndex, defaultOR: Boolean = true) {
     ): Either[String, NonEmptyList[Map[Int, Double]]] =
       queries.flatTraverse {
         case Query.TermQ(t) => Right(NonEmptyList.one(idx.scoreTFIDF(docs, t).toMap))
-        case Query.PrefixTerm(p) =>
-          NonEmptyList.fromList(idx.termsForPrefix(p)) match {
-            case None => Right(NonEmptyList.one(Map.empty[Int, Double]))
-            case Some(terms) => Right(terms.map(t => idx.scoreTFIDF(docs, t).toMap))
-          }
-        case Query.RangeQ(left, right, _, _) =>
-          (left, right) match {
-            case (Some(l), Some(r)) =>
-              // TODO handle inclusive / exclusive
-              // TODO optionality
-              // TODO left might also require special handling
-              NonEmptyList
-                .fromList(idx.termsForRange(l, r))
-                .toRight(
-                  s"No terms found while processing RangeQ: [$left, $right]"
-                )
-                .map(ts => ts.map(t => idx.scoreTFIDF(docs, t).toMap))
-            case _ => Left("Unsupport RangeQ error?")
-          }
+        case q: Query.PrefixTerm => prefixScore(idx, docs, q)
+        case q: Query.RangeQ => rangeScore(idx, docs, q)
         case Query.PhraseQ(p) =>
           // TODO Hack, only works for single term phrase
           Right(NonEmptyList.one(idx.scoreTFIDF(docs, p).toMap))
@@ -70,6 +53,33 @@ case class Scorer(index: MultiIndex, defaultOR: Boolean = true) {
       }
     accScore(defaultIdx, qs).map(combineMaps)
   }
+
+  private def prefixScore(
+      idx: Index,
+      docs: Set[Int],
+      q: Query.PrefixTerm,
+  ): Either[String, NonEmptyList[Map[Int, Double]]] =
+    NonEmptyList.fromList(idx.termsForPrefix(q.q)) match {
+      case None => Right(NonEmptyList.one(Map.empty[Int, Double]))
+      case Some(terms) => Right(terms.map(t => idx.scoreTFIDF(docs, t).toMap))
+    }
+
+  private def rangeScore(
+      idx: Index,
+      docs: Set[Int],
+      q: Query.RangeQ,
+  ): Either[String, NonEmptyList[Map[Int, Double]]] =
+    (q.lower, q.upper) match {
+      case (Some(l), Some(r)) =>
+        // TODO handle inclusive / exclusive, optionality
+        NonEmptyList
+          .fromList(idx.termsForRange(l, r))
+          .toRight(
+            s"No terms found while processing RangeQ: $q"
+          )
+          .map(ts => ts.map(t => idx.scoreTFIDF(docs, t).toMap))
+      case _ => Left(s"Unsupported RangeQ error: $q")
+    }
 
   private def combineMaps(ms: NonEmptyList[Map[Int, Double]]): List[(Int, Double)] = {
     val mb = MMap.from(ms.head)


### PR DESCRIPTION
This reorders the query matching throughout to be the same, going from term queries, to booleans, field query, and then unsupported queries.

Closes https://github.com/cozydev-pink/protosearch/issues/29