### PR TITLE
Fix prefix search for nonexistent prefixes

### DIFF
--- a/core/src/main/scala/pink/cozydev/protosearch/Index.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/Index.scala
@@ -81,7 +81,7 @@ sealed abstract class Index private (
   /** For every term starting with prefix, get the docs using those terms. */
   def docsForPrefix(prefix: String): Set[Int] = {
     var i = termIndexWhere(prefix)
-    if (termDict(i).startsWith(prefix)) {
+    if (i < termDict.length && termDict(i).startsWith(prefix)) {
       val bldr = HashSet.empty[Int]
       while (i < termDict.size)
         if (termDict(i).startsWith(prefix)) {
@@ -95,7 +95,7 @@ sealed abstract class Index private (
   /** Get the list of terms starting with prefix . */
   def termsForPrefix(prefix: String): List[String] = {
     var i = termIndexWhere(prefix)
-    if (termDict(i).startsWith(prefix)) {
+    if (i < termDict.length && termDict(i).startsWith(prefix)) {
       val bldr = ListBuffer.empty[String]
       while (i < termDict.size)
         if (termDict(i).startsWith(prefix)) {

--- a/core/src/test/scala/pink/cozydev/protosearch/IndexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/IndexSuite.scala
@@ -44,12 +44,20 @@ class IndexSuite extends munit.FunSuite {
     assertEquals(index.docsWithTerm("lazy").sorted, List(0, 2))
   }
 
+  test("docsForPrefix returns empty list when no docs contain prefix") {
+    assertEquals(index.docsForPrefix("x"), Set.empty)
+  }
+
   test("termsForPrefix returns all terms starting with prefix") {
     assertEquals(index.termsForPrefix("f"), List("fast", "fox"))
   }
 
   test("termsForPrefix returns term if it exactly matches prefix") {
     assertEquals(index.termsForPrefix("sleeps"), List("sleeps"))
+  }
+
+  test("termsForPrefix returns empty list if no prefix matches") {
+    assertEquals(index.termsForPrefix("x"), Nil)
   }
 
   test("Index.codec encodes") {

--- a/core/src/test/scala/pink/cozydev/protosearch/IndexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/IndexSuite.scala
@@ -44,8 +44,8 @@ class IndexSuite extends munit.FunSuite {
     assertEquals(index.docsWithTerm("lazy").sorted, List(0, 2))
   }
 
-  test("docsForPrefix returns empty list when no docs contain prefix") {
-    assertEquals(index.docsForPrefix("x"), Set.empty)
+  test("docsForPrefix returns empty set when no docs contain prefix") {
+    assertEquals(index.docsForPrefix("x"), Set.empty[Int])
   }
 
   test("termsForPrefix returns all terms starting with prefix") {

--- a/core/src/test/scala/pink/cozydev/protosearch/IndexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/IndexSuite.scala
@@ -44,6 +44,14 @@ class IndexSuite extends munit.FunSuite {
     assertEquals(index.docsWithTerm("lazy").sorted, List(0, 2))
   }
 
+  test("docsForPrefix returns set of docIDs containing prefixes") {
+    assertEquals(index.docsForPrefix("f"), Set(0, 1))
+  }
+
+  test("docsForPrefix returns set of docIDs containing exact term as prefix") {
+    assertEquals(index.docsForPrefix("sleeps"), Set(2))
+  }
+
   test("docsForPrefix returns empty set when no docs contain prefix") {
     assertEquals(index.docsForPrefix("x"), Set.empty[Int])
   }

--- a/core/src/test/scala/pink/cozydev/protosearch/IndexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/IndexSuite.scala
@@ -44,6 +44,16 @@ class IndexSuite extends munit.FunSuite {
     assertEquals(index.docsWithTerm("lazy").sorted, List(0, 2))
   }
 
+  test("termIndexWhere returns zero when nonexistent would insert at beginning") {
+    val indexB = Index(List(List("bb", "cc", "dd")))
+    assertEquals(indexB.termIndexWhere("a"), 0)
+  }
+
+  test("termIndexWhere returns length of termDict when nonexistent would insert at end") {
+    val indexB = Index(List(List("bb", "cc", "dd")))
+    assertEquals(indexB.termIndexWhere("x"), 3)
+  }
+
   test("docsForPrefix returns set of docIDs containing prefixes") {
     assertEquals(index.docsForPrefix("f"), Set(0, 1))
   }
@@ -56,6 +66,11 @@ class IndexSuite extends munit.FunSuite {
     assertEquals(index.docsForPrefix("x"), Set.empty[Int])
   }
 
+  test("docsForPrefix returns empty set if no prefix matches and it would insert at beginning") {
+    val indexB = Index(List(List("bb")))
+    assertEquals(indexB.docsForPrefix("a"), Set.empty[Int])
+  }
+
   test("termsForPrefix returns all terms starting with prefix") {
     assertEquals(index.termsForPrefix("f"), List("fast", "fox"))
   }
@@ -66,6 +81,11 @@ class IndexSuite extends munit.FunSuite {
 
   test("termsForPrefix returns empty list if no prefix matches") {
     assertEquals(index.termsForPrefix("x"), Nil)
+  }
+
+  test("termsForPrefix returns Nil if no prefix matches and it would insert at beginning") {
+    val indexB = Index(List(List("bb")))
+    assertEquals(indexB.termsForPrefix("a"), Nil)
   }
 
   test("Index.codec encodes") {


### PR DESCRIPTION
Fixes and `ArrayIndexOutOfBoundsException` on prefix searches where the prefix does not match any term in the term dictionary.

Thanks to @armanbilge for tracking down while things were crashing. :tada: 

```
Uncaught org.scalajs.linker.runtime.UndefinedBehaviorError: java.lang.ArrayIndexOutOfBoundsException: 4470
    at $throwArrayIndexOutOfBoundsException (main.js:60:9)
    at ArrayClass.get (main.js:644:5)
    at $c_Lpink_cozydev_protosearch_Index$$anon$1.docsForPrefix__T__sci_Set (main.js:33850:72)
    at $p_Lpink_cozydev_protosearch_BooleanRetrieval__booleanModel__Lpink_cozydev_lucille_Query__s_util_Either (main.js:103078:81)
    at $c_Lpink_cozydev_protosearch_BooleanRetrieval.search__Lpink_cozydev_lucille_Query__s_util_Either (main.js:103334:14)
    at $p_Lpink_cozydev_protosearch_MultiIndex__booleanModel__Lpink_cozydev_lucille_Query__s_util_Either (main.js:103646:78)
```