### PR TITLE
Fix query access in web worker onmessage

### DIFF
--- a/docs/interop/worker.js
+++ b/docs/interop/worker.js
@@ -31,7 +31,7 @@ async function searchIt(query) {
 }
 
 onmessage = async function(e) {
-  const query = e.data[0] || '' // empty strings become undefined somehow ...
+  const query = e.data || '' // empty strings become undefined somehow ...
   this.postMessage(await searchIt(query))
 }
 


### PR DESCRIPTION
Previously we were only grabbing the first letter of the query string in the web worker.

![Screenshot 2023-07-16 at 19-17-54 JS Interop Search](https://github.com/cozydev-pink/protosearch/assets/5440389/8de1254f-427b-4e5f-91dc-c054cc913e8c)


I was looking at http://www.devdoc.net/web/developer.mozilla.org/en-US/docs/Web/API/Worker/onmessage.html

And it looks like `e.data` is the whole payload, so `e.data[0]` would be accessing the first element of the payload, in our case, the first character of the query string.