### PR TITLE
Lowercase queries in JS interop demo

### DIFF
--- a/docs/interop/worker.js
+++ b/docs/interop/worker.js
@@ -31,9 +31,7 @@ async function searchIt(query) {
 }
 
 onmessage = async function(e) {
-  const rawQuery = e.data || '' // empty strings become undefined somehow ...
-  // The 'http4s-docs.idx' uses a lowercasing analyzer
-  const query = rawQuery.toLowerCase()
+  const query = e.data || '' // empty strings become undefined somehow ...
   this.postMessage(await searchIt(query))
 }
 

--- a/docs/interop/worker.js
+++ b/docs/interop/worker.js
@@ -31,7 +31,9 @@ async function searchIt(query) {
 }
 
 onmessage = async function(e) {
-  const query = e.data || '' // empty strings become undefined somehow ...
+  const rawQuery = e.data || '' // empty strings become undefined somehow ...
+  // The 'http4s-docs.idx' uses a lowercasing analyzer
+  const query = rawQuery.toLowerCase()
   this.postMessage(await searchIt(query))
 }
 

--- a/jsinterop/src/main/scala/pink/cozydev/protosearch/JsInterop.scala
+++ b/jsinterop/src/main/scala/pink/cozydev/protosearch/JsInterop.scala
@@ -36,7 +36,7 @@ class Querier(val mIndex: MultiIndex, val defaultField: String) {
   private val scorer = Scorer(mIndex)
   private val qAnalyzer = QueryAnalyzer(
     defaultField,
-    (defaultField, Analyzer.default),
+    (defaultField, Analyzer.default.withLowerCasing),
   )
   @JSExport
   def search(query: String): js.Array[Hit] = {


### PR DESCRIPTION
Resolves: https://github.com/cozydev-pink/protosearch/issues/90

The search works fine in iOS.
The problem was my iPhone automatically uppercasing the first letter in the query and the index used a lowercasing analyzer.