### PR TITLE
Upgrade to laika 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ val circeV = "0.14.6"
 val fs2V = "3.9.2"
 val http4sDomV = "0.2.10"
 val http4sV = "0.23.23"
-val laikaV = "0.19.5"
+val laikaV = "1.0.0"
 val lucilleV = "0.0.1"
 val munitCatsEffectV = "2.0.0-M3"
 val munitV = "1.0.0-M10"
@@ -90,8 +90,8 @@ lazy val laikaIO = crossProject(JVMPlatform)
       "co.fs2" %%% "fs2-io" % fs2V,
       "org.scodec" %%% "scodec-core" % scodecV(scalaVersion.value),
       "pink.cozydev" %%% "lucille" % lucilleV,
-      "org.planet42" %%% "laika-core" % laikaV,
-      "org.planet42" %%% "laika-io" % laikaV,
+      "org.typelevel" %%% "laika-core" % laikaV,
+      "org.typelevel" %%% "laika-io" % laikaV,
       "org.scalameta" %%% "munit" % munitV % Test,
       "org.typelevel" %%% "munit-cats-effect" % munitCatsEffectV % Test,
     ),

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/DocsDirectory.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/DocsDirectory.scala
@@ -20,10 +20,10 @@ import cats.data.NonEmptyList
 import cats.effect.IO
 import laika.api.MarkupParser
 import laika.format.Markdown
-import laika.io.implicits._
-import laika.markdown.github.GitHubFlavor
-import laika.parse.code.SyntaxHighlighting
-import laika.parse.markup.DocumentParser.RendererError
+import laika.format.Markdown.GitHubFlavor
+import laika.config.SyntaxHighlighting
+import laika.api.errors.RendererError
+import laika.io.syntax._
 
 object DocsDirectory {
 

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/DocsDirectory.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/DocsDirectory.scala
@@ -16,26 +16,43 @@
 
 package pink.cozydev.protosearch.analysis
 
-import cats.data.NonEmptyList
 import cats.effect.IO
 import laika.api.MarkupParser
 import laika.format.Markdown
 import laika.format.Markdown.GitHubFlavor
 import laika.config.SyntaxHighlighting
-import laika.api.errors.RendererError
 import laika.io.syntax._
+import laika.api.Renderer
+import cats.effect.IOApp
+import cats.effect.kernel.Resource
+import laika.api.errors.RendererError
+import cats.data.NonEmptyList
 
-object DocsDirectory {
+object DocsDirectory extends IOApp.Simple {
 
-  val mdParser = MarkupParser
+  val parserBuilder = MarkupParser
     .of(Markdown)
     .using(GitHubFlavor, SyntaxHighlighting)
-    .withConfigValue("laika.validateLinks", false)
+
+  val parser = parserBuilder
     .parallel[IO]
     .build
 
+  val config = parserBuilder.config
+
+  val plaintextRenderer = Renderer.of(Plaintext).withConfig(config).parallel[IO].build
+
+  val run = Resource
+    .both(parser, plaintextRenderer)
+    .use((parser, renderer) =>
+      parser
+        .fromDirectory("/home/andrew/src/github.com/cozydev/protosearch/docs")
+        .parse
+        .flatMap(tree => renderer.from(tree.root).toDirectory("outputDir").render.void)
+    )
+
   def dirToDocs(dirPath: String): IO[Seq[Either[RendererError, NonEmptyList[SubDocument]]]] =
-    mdParser.use(parser =>
+    parser.use(parser =>
       parser.fromDirectory(dirPath).parse.map { tree =>
         tree.root.allDocuments.map(IngestMarkdown.renderSubDocuments)
       }

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/DocsDirectory.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/DocsDirectory.scala
@@ -44,12 +44,12 @@ object DocsDirectory extends IOApp.Simple {
 
   val run = Resource
     .both(parser, plaintextRenderer)
-    .use((parser, renderer) =>
+    .use { case (parser, renderer) =>
       parser
         .fromDirectory("/home/andrew/src/github.com/cozydev/protosearch/docs")
         .parse
         .flatMap(tree => renderer.from(tree.root).toDirectory("outputDir").render.void)
-    )
+    }
 
   def dirToDocs(dirPath: String): IO[Seq[Either[RendererError, NonEmptyList[SubDocument]]]] =
     parser.use(parser =>

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/IndexFormat.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/IndexFormat.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pink.cozydev.protosearch.analysis
 
 import cats.effect.{Async, Resource}

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/IndexFormat.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/IndexFormat.scala
@@ -1,0 +1,49 @@
+package pink.cozydev.protosearch.analysis
+
+import cats.effect.{Async, Resource}
+import fs2.Stream
+import laika.api.format.{BinaryPostProcessor, Formatter, TwoPhaseRenderFormat, RenderFormat}
+import laika.ast.*
+import laika.io.model.{BinaryOutput, RenderedTreeRoot}
+import laika.api.builder.OperationConfig
+import laika.api.config.Config
+import laika.theme.Theme
+import java.io.OutputStream
+
+case object IndexFormat extends TwoPhaseRenderFormat[Formatter, BinaryPostProcessor.Builder] {
+
+  override def description: String = "Protosearch Index"
+
+  def interimFormat: RenderFormat[Formatter] = Plaintext
+
+  def prepareTree(tree: DocumentTreeRoot): Either[Throwable, DocumentTreeRoot] =
+    Right(tree) // no-op
+
+  /** Post processor that produces the final result based on the interim format.
+    */
+  def postProcessor: BinaryPostProcessor.Builder = new BinaryPostProcessor.Builder {
+
+    def build[F[_]: Async](config: Config, theme: Theme[F]): Resource[F, BinaryPostProcessor[F]] =
+      Resource.pure[F, BinaryPostProcessor[F]](new BinaryPostProcessor[F] {
+
+        def process(
+            result: RenderedTreeRoot[F],
+            output: BinaryOutput[F],
+            config: OperationConfig,
+        ): F[Unit] = {
+          val strs: List[String] = result.allDocuments.map(_.content).toList
+          val ss: Stream[F, Byte] = fs2.Stream.emits[F, String](strs).map(_.toByte)
+
+          val bytes: Stream[F, Byte] = ss
+          val outputStream: Resource[F, OutputStream] = output.resource
+          outputStream.use { os =>
+            val fos = Async[F].pure(os)
+            val pipe = fs2.io.writeOutputStream(fos)
+            bytes.through(pipe).compile.drain
+          }
+        }
+      })
+
+  }
+
+}

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/IndexFormat.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/IndexFormat.scala
@@ -48,9 +48,7 @@ case object IndexFormat extends TwoPhaseRenderFormat[Formatter, BinaryPostProces
             config: OperationConfig,
         ): F[Unit] = {
           val strs: List[String] = result.allDocuments.map(_.content).toList
-          val ss: Stream[F, Byte] = fs2.Stream.emits[F, String](strs).map(_.toByte)
-
-          val bytes: Stream[F, Byte] = ss
+          val bytes: Stream[F, Byte] = fs2.Stream.emits[F, String](strs).map(_.toByte)
           val outputStream: Resource[F, OutputStream] = output.resource
           outputStream.use { os =>
             val fos = Async[F].pure(os)

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/IngestMarkdown.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/IngestMarkdown.scala
@@ -27,9 +27,9 @@ import laika.ast.RootElement
 import laika.ast.Section
 import laika.ast.Text
 import laika.format.Markdown
-import laika.markdown.github.GitHubFlavor
-import laika.parse.code.SyntaxHighlighting
-import laika.parse.markup.DocumentParser.RendererError
+import laika.format.Markdown.GitHubFlavor
+import laika.config.SyntaxHighlighting
+import laika.api.errors.{RendererError, TransformationError}
 
 case class SubDocument(fileName: String, anchor: Option[String], title: String, content: String)
 
@@ -87,10 +87,9 @@ object IngestMarkdown {
     subDocs.sequence
   }
 
-  def transform(input: String): Either[RendererError, NonEmptyList[SubDocument]] =
+  def transform(input: String): Either[TransformationError, NonEmptyList[SubDocument]] =
     parser
       .parse(input)
-      .leftMap(e => RendererError(e.message, e.path))
       .flatMap(renderSubDocuments)
 
 }

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
@@ -60,10 +60,5 @@ case object Plaintext extends RenderFormat[Formatter] {
     PlaintextRenderer
 
   val formatterFactory: Formatter.Context[Formatter] => Formatter =
-    PlaintextFormatter
-}
-
-object PlaintextFormatter extends (Formatter.Context[Formatter] => Formatter) {
-  def apply(context: Formatter.Context[Formatter]): Formatter =
-    Formatter.defaultFactory(context.withIndentation(Formatter.Indentation.default))
+    context => Formatter.defaultFactory(context.withIndentation(Formatter.Indentation.default))
 }

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
@@ -17,21 +17,18 @@
 package pink.cozydev.protosearch.analysis
 
 import laika.ast._
-import laika.render.TextFormatter
-import laika.factory.RenderFormat
-import laika.factory.RenderContext
-import laika.render.Indentation
+import laika.api.format.{Formatter, RenderFormat}
 
-object PlaintextRenderer extends ((TextFormatter, Element) => String) {
+object PlaintextRenderer extends ((Formatter, Element) => String) {
 
-  private case class Content(content: Seq[Element], options: Options = NoOpt)
+  private case class Content(content: Seq[Element], options: Options = Options.empty)
       extends Element
       with ElementContainer[Element] {
     type Self = Content
     def withOptions(options: Options): Content = copy(options = options)
   }
 
-  def apply(fmt: TextFormatter, element: Element): String = {
+  def apply(fmt: Formatter, element: Element): String = {
 
     def renderElement(e: Element): String = {
       val (elements, _) = e.productIterator.partition(_.isInstanceOf[Element])
@@ -56,15 +53,17 @@ object PlaintextRenderer extends ((TextFormatter, Element) => String) {
   }
 }
 
-case object Plaintext extends RenderFormat[TextFormatter] {
+case object Plaintext extends RenderFormat[Formatter] {
   val fileSuffix = "txt"
 
-  val defaultRenderer: (TextFormatter, Element) => String = PlaintextRenderer
+  val defaultRenderer: (Formatter, Element) => String =
+    PlaintextRenderer
 
-  val formatterFactory: RenderContext[TextFormatter] => TextFormatter = PlaintextFormatter
+  val formatterFactory: Formatter.Context[Formatter] => Formatter =
+    PlaintextFormatter
 }
 
-object PlaintextFormatter extends (RenderContext[TextFormatter] => TextFormatter) {
-  def apply(context: RenderContext[TextFormatter]): TextFormatter =
-    TextFormatter(context.renderChild, context.root, Nil, Indentation.default)
+object PlaintextFormatter extends (Formatter.Context[Formatter] => Formatter) {
+  def apply(context: Formatter.Context[Formatter]): Formatter =
+    Formatter.defaultFactory(context.withIndentation(Formatter.Indentation.default))
 }

--- a/searchdocs-io/src/main/scala-3/pink/cozydev/protosearch/DocumentationIndexWriterApp.scala
+++ b/searchdocs-io/src/main/scala-3/pink/cozydev/protosearch/DocumentationIndexWriterApp.scala
@@ -23,7 +23,7 @@ import io.circe.syntax._
 import fs2.{Chunk, Stream}
 import fs2.io.file.{Files, Path}
 import fs2.text.utf8
-import laika.parse.markup.DocumentParser.RendererError
+import laika.api.errors.TransformationError
 import pink.cozydev.protosearch.analysis.DocsDirectory
 import pink.cozydev.protosearch.analysis.SubDocument
 
@@ -35,7 +35,7 @@ object DocumentationIndexWriterApp extends IOApp.Simple {
   val pathHttp4sDocs = pathHttp4s / "docs/docs/"
 
   def collectDocs(
-      subDocs: Either[RendererError, NonEmptyList[SubDocument]]
+      subDocs: Either[TransformationError, NonEmptyList[SubDocument]]
   ): List[Doc] =
     subDocs match {
       case Left(_) => Nil // swallow errors


### PR DESCRIPTION
This PR upgrades to laika 1.0.0

The two important pieces are:
- `Plaintext` which implements `RenderFormat[Formatter]`
- `IndexFormat` which implements the `TwoPhaseRenderFormat[Formatter, BinaryPostProcessor.Builder]`

`Plaintext` runs on every document.
`IndexFormat` renders a tree of documents that have been formatted with `Plaintext`

This follows the approach outlined in https://github.com/cozydev-pink/protosearch/issues/102#issuecomment-1793738954

The `DocsDirectory` file is upgraded, but this really is not the intended way to use things going forward.