### PR TITLE
Sort results in Scorer

### DIFF
--- a/core/src/main/scala/pink/cozydev/protosearch/Scorer.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/Scorer.scala
@@ -109,6 +109,6 @@ case class Scorer(index: MultiIndex, defaultOR: Boolean = true) {
     ms.tail.foreach(m1 =>
       m1.foreach { case (k: Int, v: Double) => mb.update(k, v + mb.getOrElse(k, 0.0)) }
     )
-    mb.iterator.toList
+    mb.toList.sortBy(idScore => (-idScore._2, idScore._1))
   }
 }

--- a/core/src/main/scala/pink/cozydev/protosearch/Scorer.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/Scorer.scala
@@ -25,9 +25,10 @@ import pink.cozydev.protosearch.internal.PositionalIter
 
 case class Scorer(index: MultiIndex, defaultOR: Boolean = true) {
 
+  private val defaultIdx: Index = index.indexes(index.defaultField)
+
   def score(qs: NonEmptyList[Query], docs: Set[Int]): Either[String, List[(Int, Double)]] = {
-    // TODO unsafe
-    val defaultIdx: Index = index.indexes(index.defaultField)
+
     def accScore(
         idx: Index,
         queries: NonEmptyList[Query],
@@ -57,7 +58,7 @@ case class Scorer(index: MultiIndex, defaultOR: Boolean = true) {
     accScore(defaultIdx, qs).map(combineMaps)
   }
 
-  def phraseScore(
+  private def phraseScore(
       idx: Index,
       docs: Set[Int],
       q: Query.Phrase,

--- a/core/src/test/scala/pink/cozydev/protosearch/ScorerSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/ScorerSuite.scala
@@ -40,13 +40,7 @@ class ScorerSuite extends munit.FunSuite {
       .flatMap(q => scorer.score(q.qs, docs))
 
   def ordered(hits: Either[String, List[(Int, Double)]]): List[Int] =
-    hits.fold(_ => Nil, ds => ds.sortBy { case (docId, score) => (-score, docId) }.map(_._1))
-
-  test("helper ordered returns list of Ints ordered by descending score") {
-    val hits: Either[String, List[(Int, Double)]] =
-      Right(List((2, 0.4), (3, 0.6), (1, 0.2)))
-    assertEquals(ordered(hits), List(3, 2, 1))
-  }
+    hits.fold(_ => Nil, ds => ds.map(_._1))
 
   test("doc with matching term is ordered first") {
     val hits = score("Bad", Set(1))

--- a/sbt/src/main/resources/pink/cozydev/protosearch/sbt/worker.js
+++ b/sbt/src/main/resources/pink/cozydev/protosearch/sbt/worker.js
@@ -40,7 +40,6 @@ function render(hit) {
 async function searchIt(query) {
   const querier = await querierPromise
   return querier.search(query)
-    .sort((h1, h2) => h1.score < h2.score)
     .map(render)
     .join("\n")
 }


### PR DESCRIPTION
This PR moves the result scoring out of the frontend and into the Scorer.

Resolves https://github.com/cozydev-pink/protosearch/issues/153
Related to https://github.com/cozydev-pink/protosearch/issues/160