### PR TITLE
Bundle search UI as a theme extension

### DIFF
--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.html
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>JS Interop Search</title>
+  <link href=" https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css " rel="stylesheet">
+</head>
+
+<body>
+  <section class="section">
+    <h1 class="title">Demo: JS Interop</h1>
+    <p class="subtitle">
+      Search from Javascript!
+    </p>
+  </section>
+
+  <div class="container is-widescreen">
+    <section class="section">
+      <input id="search_input" class="input is-primary" type="text" placeholder="search">
+    </section>
+    <section class="section">
+       <div id="app"></div>
+    </section>
+  </div>
+
+  <script type="text/javascript" src="search.js"></script>
+</body>
+
+</html>

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.js
@@ -1,0 +1,14 @@
+async function main() {
+  var app = document.getElementById("app")
+  var searchBar = document.getElementById("search_input")
+
+  const worker = new Worker("worker.js")
+  worker.onmessage = function(e) {
+    app.innerHTML = e.data
+  }
+
+  searchBar.addEventListener('input', function () {
+    worker.postMessage(this.value)
+  })
+}
+main()

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/worker.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/worker.js
@@ -1,0 +1,52 @@
+importScripts("./protosearch.js")
+
+async function getQuerier() {
+  let querier = fetch("./searchIndex.idx")
+    .then(res => res.blob())
+    .then(blob => QuerierBuilder.load(blob))
+    .catch((error) => console.error("getQuerier error: ", error));
+  return await querier
+}
+const querierPromise = getQuerier()
+
+function render(hit) {
+  const path = hit.fields.path
+  const link = "../" + hit.fields.path.replace(".txt", ".html")
+  const title = hit.fields.title
+  const preview = hit.fields.body.slice(0, 150) + "..."
+  return (
+`
+<ol>
+  <div class="card">
+    <div class="card-content">
+      <p class="is-size-6 has-text-grey-light">
+        <span>${path}</span>
+      </p>
+      <div class="level-left">
+        <p class="title is-capitalized is-flex-wrap-wrap">
+          <a href="${link}" target="_blank">
+            <span>${title}</span>
+          </a>
+        </p>
+      </div>
+      <p class="subtitle">${preview}</p>
+    </div>
+  </div>
+</ol>
+`
+  )
+}
+
+async function searchIt(query) {
+  const querier = await querierPromise
+  return querier.search(query)
+    .map(render)
+    .join("\n")
+}
+
+onmessage = async function(e) {
+  const query = e.data || '' // empty strings become undefined somehow ...
+  this.postMessage(await searchIt(query))
+}
+
+searchIt("warmup")

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/ui/SearchUI.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/ui/SearchUI.scala
@@ -1,0 +1,34 @@
+package pink.cozydev.protosearch.ui
+
+import cats.effect.{Async, Resource}
+import laika.ast.Path
+import laika.io.model.InputTree
+import laika.theme.{Theme, ThemeBuilder, ThemeProvider}
+
+object SearchUI extends ThemeProvider {
+
+  def build[F[_]: Async]: Resource[F, Theme[F]] = {
+
+    val path = "pink/cozydev/protosearch/sbt"
+
+    val inputs = InputTree[F]
+      .addClassLoaderResource(
+        s"$path/protosearch.js",
+        Path.Root / "search" / "protosearch.js",
+      )
+      .addClassLoaderResource(
+        s"$path/search.js",
+        Path.Root / "search" / "search.js",
+      )
+      .addClassLoaderResource(
+        s"$path/worker.js",
+        Path.Root / "search" / "worker.js",
+      )
+      .addClassLoaderResource(
+        s"$path/search.html",
+        Path.Root / "search" / "search.html",
+      )
+
+    ThemeBuilder[F]("protosearch UI").addInputs(inputs).build
+  }
+}


### PR DESCRIPTION
This PR duplicates the resources from the sbt plugin into the `laikaIO` module and bundles them as a theme provider.
Note that the plugin references 4 files, but I could only see 3.

A plugin user can then simply apply both the UI and the index renderer with standard Laika settings (once 1.1 is out):

```scala
laikaTheme := Helium.defaults.extendWith(SearchUI).build

laikaRenderers += BinaryRendererConfig(
  alias = "index",
  format = IndexFormat,
  targetDirectory = new File(protosearchIndexTarget.value / "search"),
  artifactBaseName = "searchIndex",
  fileSuffix = "dat",
  includeInSite = someCustomSetting.value,
  supportsSeparations = false
)
```

If you'd keep the plugin, that's all that would be inside, which is why it's probably not necessary to keep publishing it.

An API user can then as easily use `IndexFormat` and `SearchUI`:

```scala
val indexRenderer = Renderer
  .of(IndexFormat)
  .parallel[IO]
  .build

val htmlRenderer = Renderer
  .of(HTML)
  .parallel[IO]
  .withTheme(Helium.defaults.extendWith(SearchUI).build)
  .build
```

