### PR TITLE
Fix Page Navigation On Small Screens

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -156,6 +156,8 @@ lazy val docs = project
           homeLink = IconLink.internal(Root / "index.md", HeliumIcon.home)
         )
         .site
+        .pageNavigation(keepOnSmallScreens = true)
+        .site
         .mainNavigation(appendLinks =
           Seq(
             ThemeNavigationSection(


### PR DESCRIPTION
This PR is to add Page Navigation on Small Screens which is false by default.

This is how it will look on Smaller screens-

![image](https://github.com/cozydev-pink/protosearch/assets/157791077/1e22cbd1-e04b-44e6-b823-92478d2c5fbc)

@valencik Please review