### PR TITLE
Add and searchbar to the laika navbar

### DIFF
--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
@@ -1,3 +1,7 @@
+.search-row {
+  margin-left: auto; /* Pin top search bar to right, near links */
+}
+
 #top-bar-search {
   background-color: var(--component-area-bg);
   border: 1px solid var(--primary-medium);

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
@@ -36,11 +36,11 @@
 /* Modal Content/Box */
 .search-modal-content {
   background-color: var(--bg-color);
-  margin: 15% auto; /* 15% from the top and centered */
-  padding: 20px;
+  margin: 1px auto; /* at the top and centered */
+  padding: 0px 20px 40px;
   width: 80%; /* Could be more or less, depending on screen size */
   border: 1px solid var(--primary-medium);
-  border-radius: 5px;
+  border-radius: 8px;
 }
 
 .search-modal-content span {

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
@@ -1,8 +1,8 @@
 #top-bar-search {
-  background-color: var(--syntax-base1);
+  background-color: var(--component-area-bg);
+  border: 1px solid var(--primary-medium);
+  color: var(--primary-color);
   border-radius: 5px;
-  border-style: solid;
-  border-width: 1px;
   height: 24px;
   padding-left: 10px;
 }
@@ -23,10 +23,10 @@
 }
 
 #search-modal-input {
-  background-color: var(--syntax-base1);
+  background-color: var(--component-area-bg);
+  border: 1px solid var(--primary-medium);
+  color: var(--primary-color);
   border-radius: 5px;
-  border-style: solid;
-  border-width: 1px;
   height: 28px;
   width: 80%;
   margin: 10px 25px 10px 25px;
@@ -39,7 +39,7 @@
   margin: 15% auto; /* 15% from the top and centered */
   padding: 20px;
   width: 80%; /* Could be more or less, depending on screen size */
-  border: 1px solid var(--component-color);
+  border: 1px solid var(--primary-medium);
   border-radius: 5px;
 }
 
@@ -49,7 +49,6 @@
 
 /* The Close Button */
 .search-close {
-  color: #aaa;
   float: right;
   font-size: 28px;
   font-weight: bold;
@@ -57,7 +56,7 @@
 
 .search-close:hover,
 .search-close:focus {
-  color: black;
+  color: var(--primary-medium);
   text-decoration: none;
   cursor: pointer;
 }

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
@@ -2,3 +2,47 @@
   background-color: var(--syntax-base1);
   border-radius: 0.375rem;
 }
+
+/* Modal CSS setup from https://www.w3schools.com/howto/howto_css_modals.asp */
+/* The Modal (background) */
+.search-modal {
+  display: none; /* Hidden by default */
+  position: fixed; /* Stay in place */
+  z-index: 1; /* Sit on top */
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto; /* Enable scroll if needed */
+  background-color: rgb(0,0,0); /* Fallback color */
+  background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
+}
+
+/* Modal Content/Box */
+.search-modal-content {
+  background-color: var(--bg-color);
+  margin: 15% auto; /* 15% from the top and centered */
+  padding: 20px;
+  width: 80%; /* Could be more or less, depending on screen size */
+  border: 1px solid var(--component-color);
+  border-radius: 5px;
+}
+
+.search-modal-content span {
+  color: var(--secondary-color);
+}
+
+/* The Close Button */
+.search-close {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+}
+
+.search-close:hover,
+.search-close:focus {
+  color: black;
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
@@ -2,7 +2,7 @@
   margin-left: auto; /* Pin top search bar to right, near links */
 }
 
-#top-bar-search {
+#search-top-bar {
   background-color: var(--component-area-bg);
   border: 1px solid var(--primary-medium);
   color: var(--primary-color);

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
@@ -21,6 +21,17 @@
   background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
 }
 
+#search-modal-input {
+  background-color: var(--syntax-base1);
+  border-radius: 5px;
+  border-style: solid;
+  border-width: 1px;
+  height: 28px;
+  width: 80%;
+  margin: 10px 25px 10px 25px;
+  padding-left: 10px;
+}
+
 /* Modal Content/Box */
 .search-modal-content {
   background-color: var(--bg-color);

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
@@ -4,6 +4,7 @@
   border-style: solid;
   border-width: 1px;
   height: 24px;
+  padding-left: 10px;
 }
 
 /* Modal CSS setup from https://www.w3schools.com/howto/howto_css_modals.asp */

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
@@ -1,0 +1,4 @@
+#top-bar-search {
+  background-color: var(--syntax-base1);
+  border-radius: 0.375rem;
+}

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
@@ -1,6 +1,9 @@
 #top-bar-search {
   background-color: var(--syntax-base1);
-  border-radius: 0.375rem;
+  border-radius: 5px;
+  border-style: solid;
+  border-width: 1px;
+  height: 24px;
 }
 
 /* Modal CSS setup from https://www.w3schools.com/howto/howto_css_modals.asp */

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
@@ -1,13 +1,17 @@
 async function main() {
-  //var app = document.getElementById("app")
-  const searchBar = document.getElementById("top-bar-search")
   const modal = document.getElementById("top-bar-search-modal");
+  const modalSearch = document.getElementById("search-modal-input");
   const modalBody = document.getElementById("search-modal-content-body");
 
-  // Get the <span> element that closes the modal
-  var span = document.getElementsByClassName("search-close")[0];
+  const searchController = document.getElementById("top-bar-search")
+  searchController.onclick = function() {
+    modal.style.display = "block"
+    modalSearch.focus()
+  }
+
   // When the user clicks on <span> (x), close the modal
-  span.onclick = function() {
+  const modalClose = document.getElementsByClassName("search-close")[0];
+  modalClose.onclick = function() {
     modal.style.display = "none";
   }
   // When the user clicks anywhere outside of the modal, close it
@@ -17,17 +21,18 @@ async function main() {
     }
   }
 
+  // Setup the search worker, it returns inner html to the modal
   const worker = new Worker("/search/searchBarWorker.js")
   worker.onmessage = function(e) {
-    modal.style.display = "block"
     modalBody.innerHTML = e.data
   }
-
-  searchBar.addEventListener('input', function () {
+  // Send inputs to the search worker
+  modalSearch.addEventListener('input', function () {
     worker.postMessage(this.value)
   })
 }
 
+// Only run once page has finished loading
 window.onload = function() {
   main()
 }

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
@@ -1,12 +1,12 @@
 async function main() {
-  const modal = document.getElementById("top-bar-search-modal");
-  const modalSearch = document.getElementById("search-modal-input");
+  const modal = document.getElementById("search-modal");
+  const modalInput = document.getElementById("search-modal-input");
   const modalBody = document.getElementById("search-modal-content-body");
 
-  const searchController = document.getElementById("top-bar-search")
-  searchController.onclick = function() {
+  const searchTopBar = document.getElementById("search-top-bar")
+  searchTopBar.onclick = function() {
     modal.style.display = "block"
-    modalSearch.focus()
+    modalInput.focus()
   }
 
   // When the user clicks on <span> (x), close the modal
@@ -27,7 +27,7 @@ async function main() {
     modalBody.innerHTML = e.data
   }
   // Send inputs to the search worker
-  modalSearch.addEventListener('input', function () {
+  modalInput.addEventListener('input', function () {
     worker.postMessage(this.value)
   })
 }

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
@@ -1,0 +1,33 @@
+async function main() {
+  //var app = document.getElementById("app")
+  const searchBar = document.getElementById("top-bar-search")
+  const modal = document.getElementById("top-bar-search-modal");
+  const modalBody = document.getElementById("search-modal-content-body");
+
+  // Get the <span> element that closes the modal
+  var span = document.getElementsByClassName("search-close")[0];
+  // When the user clicks on <span> (x), close the modal
+  span.onclick = function() {
+    modal.style.display = "none";
+  }
+  // When the user clicks anywhere outside of the modal, close it
+  window.onclick = function(event) {
+    if (event.target == modal) {
+      modal.style.display = "none";
+    }
+  }
+
+  const worker = new Worker("/search/searchBarWorker.js")
+  worker.onmessage = function(e) {
+    modal.style.display = "block"
+    modalBody.innerHTML = e.data
+  }
+
+  searchBar.addEventListener('input', function () {
+    worker.postMessage(this.value)
+  })
+}
+
+window.onload = function() {
+  main()
+}

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBarWorker.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBarWorker.js
@@ -1,0 +1,47 @@
+importScripts("./protosearch.js")
+
+async function getQuerier() {
+  let querier = fetch("./searchIndex.idx")
+    .then(res => res.blob())
+    .then(blob => QuerierBuilder.load(blob))
+    .catch((error) => console.error("getQuerier error: ", error));
+  return await querier
+}
+const querierPromise = getQuerier()
+
+function render(hit) {
+  const path = hit.fields.path
+  const link = "../" + hit.fields.path.replace(".txt", ".html")
+  const title = hit.fields.title
+  const preview = hit.fields.body.slice(0, 150) + "..."
+  return (
+`
+<ol>
+  <div class="card">
+    <div class="level-left">
+      <p class="title">
+        <a href="${link}" target="_blank">
+          <span>${title}</span>
+        </a>
+      </p>
+    </div>
+    <p class="subtitle">${preview}</p>
+  </div>
+</ol>
+`
+  )
+}
+
+async function searchIt(query) {
+  const querier = await querierPromise
+  return querier.search(query)
+    .map(render)
+    .join("\n")
+}
+
+onmessage = async function(e) {
+  const query = e.data || '' // empty strings become undefined somehow ...
+  this.postMessage(await searchIt(query))
+}
+
+searchIt("warmup")

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/topNav.template.html
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/topNav.template.html
@@ -13,6 +13,12 @@
   <div class="row">
     <input id="top-bar-search" class="input" type="text" placeholder="Search">
   </div>
+  <div id="top-bar-search-modal" class="search-modal">
+    <div class="search-modal-content">
+      <span class="search-close">&times;</span>
+      <div id="search-modal-content-body"></div>
+    </div>
+  </div>
 
   <div class="row links">
     @:for(helium.site.topNavigation.links)

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/topNav.template.html
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/topNav.template.html
@@ -11,9 +11,9 @@
   ${?helium.site.topNavigation.home}
 
   <div class="row search-row">
-    <input id="top-bar-search" class="input" type="text" placeholder="Search">
+    <input id="search-top-bar" class="input" type="text" placeholder="Search">
   </div>
-  <div id="top-bar-search-modal" class="search-modal">
+  <div id="search-modal" class="search-modal">
     <div class="search-modal-content">
       <span class="search-close">&times;</span>
       <input id="search-modal-input" class="input" type="text">

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/topNav.template.html
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/topNav.template.html
@@ -10,7 +10,7 @@
 
   ${?helium.site.topNavigation.home}
 
-  <div class="row">
+  <div class="row search-row">
     <input id="top-bar-search" class="input" type="text" placeholder="Search">
   </div>
   <div id="top-bar-search-modal" class="search-modal">

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/topNav.template.html
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/topNav.template.html
@@ -1,0 +1,23 @@
+<header id="top-bar" class="${helium.site.topNavigation.style}">
+
+  <div class="row">
+    <a id="nav-icon">
+      @:icon(navigationMenu)
+    </a>
+
+    ${helium.site.topNavigation.versionMenu}
+  </div>
+
+  ${?helium.site.topNavigation.home}
+
+  <div class="row">
+    <input id="top-bar-search" class="input" type="text" placeholder="Search">
+  </div>
+
+  <div class="row links">
+    @:for(helium.site.topNavigation.links)
+    ${_}
+    @:@
+  </div>
+
+</header>

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/topNav.template.html
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/topNav.template.html
@@ -16,6 +16,7 @@
   <div id="top-bar-search-modal" class="search-modal">
     <div class="search-modal-content">
       <span class="search-close">&times;</span>
+      <input id="search-modal-input" class="input" type="text">
       <div id="search-modal-content-body"></div>
     </div>
   </div>

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/ui/SearchUI.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/ui/SearchUI.scala
@@ -20,6 +20,7 @@ import cats.effect.{Async, Resource}
 import laika.ast.Path
 import laika.io.model.InputTree
 import laika.theme.{Theme, ThemeBuilder, ThemeProvider}
+import laika.helium.Helium
 
 object SearchUI extends ThemeProvider {
 
@@ -44,7 +45,20 @@ object SearchUI extends ThemeProvider {
         s"$path/search.html",
         Path.Root / "search" / "search.html",
       )
+      .addClassLoaderResource(
+        s"$path/search.css",
+        Path.Root / "search" / "search.css",
+      )
+      .addClassLoaderResource(
+        s"$path/topNav.template.html",
+        Path.Root / "helium" / "templates" / "topNav.template.html",
+      )
 
     ThemeBuilder[F]("protosearch UI").addInputs(inputs).build
   }
+
+  // Make a Helium => Helium function
+  // so we can leverage: .extendWith(Helium => Helium)
+  def searchNavBar(helium: Helium): Helium =
+    helium.site.internalCSS(Path.Root / "search" / "search.css")
 }

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/ui/SearchUI.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/ui/SearchUI.scala
@@ -42,11 +42,11 @@ object SearchUI extends ThemeProvider {
         Path.Root / "search" / "worker.js",
       )
       .addClassLoaderResource(
-        s"$path/search.js",
+        s"$path/searchBar.js",
         Path.Root / "search" / "searchBar.js",
       )
       .addClassLoaderResource(
-        s"$path/worker.js",
+        s"$path/searchBarWorker.js",
         Path.Root / "search" / "searchBarWorker.js",
       )
       .addClassLoaderResource(

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/ui/SearchUI.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/ui/SearchUI.scala
@@ -42,6 +42,14 @@ object SearchUI extends ThemeProvider {
         Path.Root / "search" / "worker.js",
       )
       .addClassLoaderResource(
+        s"$path/search.js",
+        Path.Root / "search" / "searchBar.js",
+      )
+      .addClassLoaderResource(
+        s"$path/worker.js",
+        Path.Root / "search" / "searchBarWorker.js",
+      )
+      .addClassLoaderResource(
         s"$path/search.html",
         Path.Root / "search" / "search.html",
       )
@@ -60,5 +68,12 @@ object SearchUI extends ThemeProvider {
   // Make a Helium => Helium function
   // so we can leverage: .extendWith(Helium => Helium)
   def searchNavBar(helium: Helium): Helium =
-    helium.site.internalCSS(Path.Root / "search" / "search.css")
+    helium.site
+      .internalCSS(Path.Root / "search" / "search.css")
+      .site
+      .internalJS(Path.Root / "search" / "protosearch.js")
+      .site
+      .internalJS(Path.Root / "search" / "searchBar.js")
+      .site
+      .internalJS(Path.Root / "search" / "searchBarWorker.js")
 }

--- a/sbt/src/main/scala/pink/cozydev/protosearch/ProtosearchPlugin.scala
+++ b/sbt/src/main/scala/pink/cozydev/protosearch/ProtosearchPlugin.scala
@@ -31,7 +31,10 @@ object ProtosearchPlugin extends AutoPlugin {
   override def requires = plugins.JvmPlugin && TypelevelSitePlugin
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
-    laikaTheme := tlSiteHelium.value.extendWith(SearchUI).build,
+    laikaTheme := tlSiteHelium.value
+      .extendWith(SearchUI)
+      .extendWith(SearchUI.searchNavBar(_))
+      .build,
     laikaRenderers += IndexRendererConfig(includeInSite = true),
   )
 }


### PR DESCRIPTION
This PR adds a search bar to the top nav of the Laika Helium theme.
Interacting with the search bar opens a modal where search results are displayed as you type.

<img width="1021" alt="search bar in nav" src="https://github.com/user-attachments/assets/0182d42a-456c-42a8-8778-dbb95ade9bb6">

<img width="1009" alt="search modal with results" src="https://github.com/user-attachments/assets/3a52ce41-c612-4393-a10c-45688274410b">

Resolves https://github.com/cozydev-pink/protosearch/issues/49
(I mean, it's a work in progress, but so is everything!)