### PR TITLE
increase accuracy and test coverage for PlaintextRenderer

### DIFF
--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
@@ -38,6 +38,18 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
       case _ => fmt.children(con.content)
     }
 
+    def renderBlockContainer(con: BlockContainer): String = con match {
+      /* Some special handling for the few containers which hold child nodes
+         in more properties than just the container's `content` property.
+       */
+      case Section(header, content, _) => renderBlock(header.content) + renderBlocks(content)
+      case QuotedBlock(content, attr, _) => renderBlocks(content) + renderBlock(attr)
+      case TitledBlock(title, content, _) => renderBlock(title) + renderBlocks(content)
+      case Figure(_, caption, content, _) => renderBlock(caption) + renderBlocks(content)
+      case DefinitionListItem(term, defn, _) => renderBlock(term) + renderBlocks(defn)
+      case _ => renderBlocks(con.content)
+    }
+
     def renderBlocks(blocks: Seq[Block]): String =
       if (blocks.nonEmpty) fmt.childPerLine(blocks) + fmt.newLine
       else ""
@@ -48,11 +60,8 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
 
     element match {
       case lc: ListContainer => renderListContainer(lc)
-      case s: Section => renderBlock(s.header.content) + renderBlocks(s.content)
+      case bc: BlockContainer => renderBlockContainer(bc)
       case _: SectionNumber => ""
-      case QuotedBlock(content, attr, _) => renderBlocks(content) + renderBlock(attr)
-      case DefinitionListItem(term, defn, _) => renderBlock(term) + renderBlocks(defn)
-      case bc: BlockContainer => renderBlocks(bc.content)
       case tc: TextContainer => tc.content
       case ec: ElementContainer[_] => fmt.children(ec.content)
       case e => renderElement(e)

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
@@ -76,6 +76,11 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
       case _ => con.content
     }
 
+    def renderTable(table: Table): String = {
+      val cells = (table.head.content ++ table.body.content).flatMap(_.content)
+      renderBlocks(cells.flatMap(_.content)) + renderBlock(table.caption.content)
+    }
+
     def renderBlocks(blocks: Seq[Block]): String =
       if (blocks.nonEmpty) fmt.childPerLine(blocks) + fmt.newLine
       else ""
@@ -95,6 +100,7 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
       case ec: ElementContainer[?] => renderElementContainer(ec)
       case tc: TextContainer => renderTextContainer(tc)
       case _: HTMLSpan => ""
+      case t: Table => renderTable(t)
       case e => renderElement(e)
     }
   }

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
@@ -55,7 +55,7 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
       /* SectionInfo is solely used in navigation structures and represents duplicate info.
        */
       case _: SectionInfo => ""
-      /* All other core AST types implement one of the sub-traits of `ElementContainer` -
+      /* All other core AST types implement one of the sub-traits of ElementContainer -
          if we end up here it's an unknown 3rd party node
        */
       case _ => fmt.children(con.content)
@@ -85,6 +85,10 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
       else ""
 
     element match {
+      /* These are marker traits for nodes we should ignore.
+       * They usually also implement some of the other traits we match on,
+       * so this always needs to come first. */
+      case _: Hidden | _: Unresolved | _: Invalid => ""
       case lc: ListContainer => renderListContainer(lc)
       case bc: BlockContainer => renderBlockContainer(bc)
       case sc: SpanContainer => fmt.children(sc.content)

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
@@ -30,6 +30,14 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
       )
     }
 
+    def renderListContainer(con: ListContainer): String = con match {
+      /* Excluded as they would either produce unwanted entries (e.g. the headline of a different page)
+       * or duplicate entries (e.g. a section title on the current page)
+       */
+      case _: NavigationList | _: NavigationItem => ""
+      case _ => fmt.children(con.content)
+    }
+
     def renderBlocks(blocks: Seq[Block]): String =
       if (blocks.nonEmpty) fmt.childPerLine(blocks) + fmt.newLine
       else ""
@@ -39,6 +47,7 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
       else ""
 
     element match {
+      case lc: ListContainer => renderListContainer(lc)
       case s: Section => renderBlock(s.header.content) + renderBlocks(s.content)
       case _: SectionNumber => ""
       case QuotedBlock(content, attr, _) => renderBlocks(content) + renderBlock(attr)

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
@@ -16,8 +16,9 @@
 
 package pink.cozydev.protosearch.analysis
 
-import laika.ast._
+import laika.ast.*
 import laika.api.format.{Formatter, RenderFormat}
+import laika.ast.html.HTMLSpan
 
 object PlaintextRenderer extends ((Formatter, Element) => String) {
 
@@ -25,7 +26,7 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
 
     def renderElement(e: Element): String = {
       val (elements, _) = e.productIterator.partition(_.isInstanceOf[Element])
-      e.productPrefix + fmt.indentedChildren(
+      fmt.children(
         elements.toList.asInstanceOf[Seq[Element]]
       )
     }
@@ -61,9 +62,11 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
     element match {
       case lc: ListContainer => renderListContainer(lc)
       case bc: BlockContainer => renderBlockContainer(bc)
+      case sc: SpanContainer => fmt.children(sc.content)
       case _: SectionNumber => ""
       case tc: TextContainer => tc.content
       case ec: ElementContainer[_] => fmt.children(ec.content)
+      case _: HTMLSpan => ""
       case e => renderElement(e)
     }
   }

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
@@ -51,6 +51,16 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
       case _ => renderBlocks(con.content)
     }
 
+    def renderElementContainer(con: ElementContainer[? <: Element]): String = con match {
+      /* SectionInfo is solely used in navigation structures and represents duplicate info.
+       */
+      case _: SectionInfo => ""
+      /* All other core AST types implement one of the sub-traits of `ElementContainer` -
+         if we end up here it's an unknown 3rd party node
+       */
+      case _ => fmt.children(con.content)
+    }
+
     def renderBlocks(blocks: Seq[Block]): String =
       if (blocks.nonEmpty) fmt.childPerLine(blocks) + fmt.newLine
       else ""
@@ -63,9 +73,9 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
       case lc: ListContainer => renderListContainer(lc)
       case bc: BlockContainer => renderBlockContainer(bc)
       case sc: SpanContainer => fmt.children(sc.content)
+      case ec: ElementContainer[?] => renderElementContainer(ec)
       case _: SectionNumber => ""
       case tc: TextContainer => tc.content
-      case ec: ElementContainer[_] => fmt.children(ec.content)
       case _: HTMLSpan => ""
       case e => renderElement(e)
     }

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
@@ -61,6 +61,21 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
       case _ => fmt.children(con.content)
     }
 
+    def renderTextContainer(con: TextContainer): String = con match {
+      /* match on most common container type first for performance */
+      case Text(content, _) => content
+      /* could be any unknown markup format */
+      case _: RawContent => ""
+      /* comments are usually ignored by search engines */
+      case _: Comment => ""
+      /* embedded debug info node */
+      case _: RuntimeMessage => ""
+      /* this does not represent text nodes in verbatim HTML */
+      case _: HTMLSpan => ""
+      case _: SectionNumber => ""
+      case _ => con.content
+    }
+
     def renderBlocks(blocks: Seq[Block]): String =
       if (blocks.nonEmpty) fmt.childPerLine(blocks) + fmt.newLine
       else ""
@@ -74,8 +89,7 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
       case bc: BlockContainer => renderBlockContainer(bc)
       case sc: SpanContainer => fmt.children(sc.content)
       case ec: ElementContainer[?] => renderElementContainer(ec)
-      case _: SectionNumber => ""
-      case tc: TextContainer => tc.content
+      case tc: TextContainer => renderTextContainer(tc)
       case _: HTMLSpan => ""
       case e => renderElement(e)
     }

--- a/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/PlaintextRendererSuite.scala
+++ b/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/PlaintextRendererSuite.scala
@@ -30,7 +30,7 @@ import munit.CatsEffectSuite
 class PlaintextRendererSuite extends CatsEffectSuite {
 
   val markdownParser: MarkupParser =
-    MarkupParser.of(Markdown).using(Markdown.GitHubFlavor, SyntaxHighlighting).build
+    MarkupParser.of(Markdown).using(Markdown.GitHubFlavor, SyntaxHighlighting).withRawContent.build
   val rstParser: MarkupParser =
     MarkupParser.of(ReStructuredText).build
   val plaintextRenderer: Renderer = Renderer.of(Plaintext).build
@@ -259,6 +259,21 @@ class PlaintextRendererSuite extends CatsEffectSuite {
     transformWithTemplate(doc, template).map { res =>
       assert(!res.contains("Second Doc"))
     }
+  }
+
+  /** raw content ****************************************************** */
+
+  test("extract text nodes in verbatim HTML") {
+    val doc =
+      """|<div>Excluded Text</div>
+         |
+         |Included Text
+         |""".stripMargin
+    val expected =
+      """|Excluded Text
+         |Included Text
+         |""".stripMargin
+    assertEquals(transformMarkdown(doc), Right(expected))
   }
 
 }

--- a/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/PlaintextRendererSuite.scala
+++ b/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/PlaintextRendererSuite.scala
@@ -32,7 +32,7 @@ class PlaintextRendererSuite extends CatsEffectSuite {
   val markdownParser: MarkupParser =
     MarkupParser.of(Markdown).using(Markdown.GitHubFlavor, SyntaxHighlighting).withRawContent.build
   val rstParser: MarkupParser =
-    MarkupParser.of(ReStructuredText).build
+    MarkupParser.of(ReStructuredText).withRawContent.build
   val plaintextRenderer: Renderer = Renderer.of(Plaintext).build
 
   val ioTransformer: Resource[IO, TreeTransformer[IO]] = Transformer
@@ -274,6 +274,45 @@ class PlaintextRendererSuite extends CatsEffectSuite {
          |Included Text
          |""".stripMargin
     assertEquals(transformMarkdown(doc), Right(expected))
+  }
+
+  /** exclusions ********************************************************** */
+
+  test("ignore comments - reStructuredText") {
+    val doc =
+      """|The Title
+         |=========
+         |The text
+         |
+         |.. This is a comment
+         |""".stripMargin
+    val expected =
+      """|The Title
+         |The text
+         |
+         |
+         |""".stripMargin
+    assertEquals(transformRST(doc), Right(expected))
+  }
+
+  test("ignore raw content - reStructuredText") {
+    val doc =
+      """|The Title
+         |=========
+         |The text
+         |
+         |.. raw:: format
+         |
+         | some input
+         |
+         | some more""".stripMargin
+    val expected =
+      """|The Title
+         |The text
+         |
+         |
+         |""".stripMargin
+    assertEquals(transformRST(doc), Right(expected))
   }
 
 }

--- a/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/PlaintextRendererSuite.scala
+++ b/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/PlaintextRendererSuite.scala
@@ -347,27 +347,50 @@ class PlaintextRendererSuite extends CatsEffectSuite {
          |
          |${cursor.currentDocument.content}
          |""".stripMargin
+    val expected =
+      """|First Doc
+         |
+         |""".stripMargin
     transformWithTemplate(doc, template).map { res =>
-      assert(!res.contains("Second Doc"))
+      assertEquals(res, expected)
     }
   }
 
-  /** raw content ****************************************************** */
+  /** templates and raw content ****************************************************** */
+
+  test("exclude template content except the nodes merged from the associated markup files") {
+    val doc =
+      """|First Doc
+         |=========
+         |""".stripMargin
+    val template =
+      """|<Some Funny Markup Here>
+         |
+         |${cursor.currentDocument.content}
+         |
+         |<More Funny Markup>
+         |""".stripMargin
+    val expected =
+      """|First Doc
+         |
+         |""".stripMargin
+    transformWithTemplate(doc, template).map { res =>
+      assertEquals(res, expected)
+    }
+  }
 
   test("extract text nodes in verbatim HTML") {
     val doc =
-      """|<div>Excluded Text</div>
+      """|<div>Text Node</div>
          |
          |Included Text
          |""".stripMargin
     val expected =
-      """|Excluded Text
+      """|Text Node
          |Included Text
          |""".stripMargin
     assertEquals(transformMarkdown(doc), Right(expected))
   }
-
-  /** exclusions ********************************************************** */
 
   test("ignore comments - reStructuredText") {
     val doc =

--- a/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/PlaintextRendererSuite.scala
+++ b/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/PlaintextRendererSuite.scala
@@ -115,6 +115,28 @@ class PlaintextRendererSuite extends CatsEffectSuite {
     assertEquals(transformMarkdown(doc), Right(expected))
   }
 
+  test("table head and body - Markdown with GitHub Flavor") {
+    val doc =
+      """|| AAA | BBB |
+         || --- | --- |
+         || CCC | DDD |
+         || EEE | FFF |
+         |
+         |Some more text
+      """.stripMargin
+    val expected =
+      """|AAA
+         |BBB
+         |CCC
+         |DDD
+         |EEE
+         |FFF
+         |
+         |Some more text
+         |""".stripMargin
+    assertEquals(transformMarkdown(doc), Right(expected))
+  }
+
   /** BlockContainers **************************************************** */
 
   test("nested blockquotes - Markdown") {

--- a/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/PlaintextRendererSuite.scala
+++ b/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/PlaintextRendererSuite.scala
@@ -27,6 +27,9 @@ import laika.io.model.InputTree
 import laika.io.syntax.*
 import munit.CatsEffectSuite
 
+import scala.annotation.nowarn
+
+@nowarn("msg=possible missing interpolator")
 class PlaintextRendererSuite extends CatsEffectSuite {
 
   val selections: Selections = Selections(

--- a/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/PlaintextRendererSuite.scala
+++ b/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/PlaintextRendererSuite.scala
@@ -115,6 +115,8 @@ class PlaintextRendererSuite extends CatsEffectSuite {
     assertEquals(transformMarkdown(doc), Right(expected))
   }
 
+  /** BlockContainers **************************************************** */
+
   test("nested blockquotes - Markdown") {
     val doc =
       """|>aaa
@@ -140,6 +142,37 @@ class PlaintextRendererSuite extends CatsEffectSuite {
     val expected =
       """|Paragraph 1
          |an attribution
+         |
+         |""".stripMargin
+    assertEquals(transformRST(doc), Right(expected))
+  }
+
+  test("titled block - reStructuredText") {
+    val doc =
+      """|.. caution::
+         |
+         | Line 1
+         |
+         | Line 2""".stripMargin
+    val expected =
+      """|Caution!
+         |Line 1
+         |Line 2
+         |
+         |""".stripMargin
+    assertEquals(transformRST(doc), Right(expected))
+  }
+
+  test("figure with a caption and a legend - reStructuredText") {
+    val doc =
+      """|.. figure:: picture.jpg
+         |
+         | This is the *caption*
+         |
+         | And this is the legend""".stripMargin
+    val expected =
+      """|This is the caption
+         |And this is the legend
          |
          |""".stripMargin
     assertEquals(transformRST(doc), Right(expected))


### PR DESCRIPTION
I had this on my radar for quite a while: the previous implementation of `PlaintextRenderer` was somewhat rudimentary, had a very small test suite and a fallback for unknown nodes that would create unwanted index entries.

This PR aims to:

* Significantly increase the test coverage to safeguard future maintenance - this is particularly relevant as many AST nodes in Laika implement more than one of the traits we match on, so a simple, seemingly innocent reordering of patterns matched on could break things.
* Avoid the default fallback that includes `productPrefix` in the index, as this would produce entries such as `Rule` or `PageBreak` which are unwanted. Instead the fallback now discards unknown nodes as the last step.
* Include more explicit handling of special node types that do not implement the main traits like `BlockContainer` or `TextContainer` since the fallback would now discard them. The relevant additions here are:
  * Tables
  * `BlockContainer` types that hold child nodes in more than just its `content` property (e.g. `Figure`)
  * `Image` - add `alt` and `title` attributes to the index like most search engines do
  * Extract text nodes from verbatim HTML
  * Extract AST nodes originating from markup documents from the template AST (for the unlikely case someone specifies a template for the indexer)
  * Handle some special node types like `TargetFormat`, `Selection`, `Fallback` - see comments in the new implementation for the low level details of what they do
* Also add more explicit exclusions to avoid unwanted entries, these are:
    * `Hidden` - marker trait for nodes which do not represent visual content
    * `Unresolved` - marker trait for temporary nodes that should not occur in the final result
    * `Invalid` - marker trait for invalid nodes, their presence will usually cause the transformation to fail (depending on user config)
    * `Comment` - search engines usually do not index those (AFAIK)
    * Raw content - this could be markup for example, where we cannot easily extract textual information
    * `RuntimeMessage` - this is just embedded debug info
    * `NavigationList`, `NavigationItem`, `SectionInfo` - these represent either unwanted entries (e.g. the headline of a different page linked to) or duplicate entries (e.g. a link to a section title on the current page)
    * All template nodes that do not represent AST from the merged text markup document

This PR can be reviewed per commit, if you prefer to look at more bite-sized changes.

The expansion of the test suite also required a set of new helper methods:
* Some tests now use reStructuredText instead of Markdown - some nodes we now test against are not produced by Markdown nor by Laika's directives so we need to use a text markup language that is more feature rich here. (The downside is that most people are not familiar with this syntax, the plus is that it serves as a good reminder that nothing about the indexer is specific to Markdown)
* Some tests now run in `IO` - a small number of tests now check template nodes and we need the effect-full transformer for applying templates.