### PR TITLE
Introducing SearchRequest

### DIFF
--- a/core/src/main/scala/pink/cozydev/protosearch/Field.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/Field.scala
@@ -26,7 +26,7 @@ import pink.cozydev.protosearch.analysis.Analyzer
   * @param indexed Whether the field value should be indexed for fast querying
   * @param positions Whether the positions should be indexed for fast phrase querying
   */
-case class Field(
+final case class Field(
     name: String,
     analyzer: Analyzer,
     stored: Boolean,

--- a/core/src/main/scala/pink/cozydev/protosearch/Hit.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/Hit.scala
@@ -22,7 +22,7 @@ package pink.cozydev.protosearch
   * @param score The score of this result given the query
   * @param fields Stored fields of the result
   */
-case class Hit(
+final case class Hit(
     val id: Int,
     val score: Double,
     val fields: Map[String, String],

--- a/core/src/main/scala/pink/cozydev/protosearch/Hit.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/Hit.scala
@@ -26,5 +26,5 @@ case class Hit(
     val id: Int,
     val score: Double,
     val fields: Map[String, String],
-    val highlight: String,
+    val highlights: Map[String, String],
 )

--- a/core/src/main/scala/pink/cozydev/protosearch/MultiIndex.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/MultiIndex.scala
@@ -16,56 +16,12 @@
 
 package pink.cozydev.protosearch
 
-import pink.cozydev.lucille.Query
-import pink.cozydev.protosearch.highlight.{FirstMatchHighlighter, FragmentFormatter}
-
 case class MultiIndex(
     indexes: Map[String, Index],
     schema: Schema,
     fields: Map[String, Array[String]],
 ) {
-
-  private val indexSearcher = IndexSearcher(this, schema.defaultOR)
-  private val scorer = Scorer(this, schema.defaultOR)
-  private val highlighter = FirstMatchHighlighter(FragmentFormatter(100, "<b>", "</b>"))
   val queryAnalyzer = schema.queryAnalyzer(schema.defaultField)
-
-  /** Search the index with a `Query`. Results are sorted by descending score.
-    *
-    * @param q The `Query` to search
-    * @return A list of `Hit`s or error
-    */
-  def search(rawQStr: String, q: Query): Either[String, List[Hit]] = {
-    val docs = indexSearcher.search(q).flatMap(ds => scorer.score(q, ds))
-    val lstb = List.newBuilder[Hit]
-    docs.map(_.foreach { case (docId, score) =>
-      val docFields = fields.map { case (k, v) => (k, v(docId)) }
-      val highlight =
-        docFields.get("body").map(b => highlighter.highlight(b, rawQStr)).getOrElse("")
-      lstb += Hit(docId, score, docFields, highlight)
-    })
-    docs.map(_ => lstb.result())
-  }
-
-  /** Search the index with a Lucene syntax string. Results are sorted by descending score.
-    *
-    * @param q The query string to search
-    * @return A list of `Hit`s or error
-    */
-  def search(q: String): Either[String, List[Hit]] =
-    queryAnalyzer.parse(q).flatMap(pq => search(q, pq))
-
-  /** Search the index with a possibly incomplete query. Meant for use in a "search as your type"
-    * scenario. The last term, which is possibly incomplete, is rewritten to be a prefix.
-    *
-    * @param partialQuery The possibly incomplete lucene query string
-    * @return A list of `Hit`s or error
-    */
-  def searchInteractive(partialQuery: String): Either[String, List[Hit]] = {
-    val rewriteQ =
-      queryAnalyzer.parse(partialQuery).map(mq => mq.mapLastTerm(LastTermRewrite.termToPrefix))
-    rewriteQ.flatMap(newq => search(partialQuery, newq))
-  }
 }
 object MultiIndex {
   import pink.cozydev.protosearch.codecs.IndexCodecs

--- a/core/src/main/scala/pink/cozydev/protosearch/MultiIndex.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/MultiIndex.scala
@@ -16,7 +16,7 @@
 
 package pink.cozydev.protosearch
 
-case class MultiIndex(
+final case class MultiIndex(
     indexes: Map[String, Index],
     schema: Schema,
     fields: Map[String, Array[String]],

--- a/core/src/main/scala/pink/cozydev/protosearch/Scorer.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/Scorer.scala
@@ -24,7 +24,7 @@ import pink.cozydev.protosearch.internal.PositionalIter
 
 import java.util.regex.PatternSyntaxException
 
-case class Scorer(index: MultiIndex, defaultOR: Boolean = true) {
+final case class Scorer(index: MultiIndex, defaultOR: Boolean = true) {
 
   private val defaultIdx: Index = index.indexes(index.schema.defaultField)
 

--- a/core/src/main/scala/pink/cozydev/protosearch/Scorer.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/Scorer.scala
@@ -131,23 +131,28 @@ case class Scorer(index: MultiIndex, defaultOR: Boolean = true) {
     ms.tail.foreach(m1 =>
       m1.foreach { case (k: Int, v: Double) => mb.update(k, v + mb.getOrElse(k, 0.0)) }
     )
-    // Sort scores
-    val arr = new Array[Tuple2[Int, Double]](mb.size)
-    var i = 0
-    mb.foreach { docScore =>
-      arr(i) = docScore
-      i += 1
+    val len = mb.size
+    if (len == 1)
+      mb.toList
+    else {
+      // Sort scores
+      val arr = new Array[Tuple2[Int, Double]](len)
+      var i = 0
+      mb.foreach { docScore =>
+        arr(i) = docScore
+        i += 1
+      }
+      java.util.Arrays.sort(arr, ord)
+      // Build list of topN
+      val bldr = List.newBuilder[(Int, Double)]
+      val resultSize = if (len < topN) len else topN
+      bldr.sizeHint(resultSize)
+      var n = 0
+      while (n < resultSize) {
+        bldr += arr(n)
+        n += 1
+      }
+      bldr.result()
     }
-    java.util.Arrays.sort(arr, ord)
-    // Build list of topN
-    val bldr = List.newBuilder[(Int, Double)]
-    val resultSize = if (mb.size < topN) mb.size else topN
-    bldr.sizeHint(resultSize)
-    var n = 0
-    while (n < resultSize) {
-      bldr += arr(n)
-      n += 1
-    }
-    bldr.result()
   }
 }

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
@@ -31,7 +31,6 @@ final case class SearchInterpreter(
     val parseQ = queryAnalyzer
       .parse(request.query)
       .map(q => if (request.lastTermPrefix) q.mapLastTerm(LastTermRewrite.termToPrefix) else q)
-    // TODO push down request size
     val getDocs: Either[String, List[(Int, Double)]] =
       parseQ.flatMap(q =>
         indexSearcher
@@ -57,8 +56,6 @@ final case class SearchInterpreter(
               highlightBldr += hf -> h
             }
           }
-
-          // TODO Update Hit highlight to be Map
           val highlights = highlightBldr.result()
           lstB += Hit(docId, score, fieldBldr.result(), highlights)
         }

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
@@ -59,7 +59,8 @@ final case class SearchInterpreter(
           }
 
           // TODO Update Hit highlight to be Map
-          lstB += Hit(docId, score, fieldBldr.result(), highlightBldr.result().head._2)
+          val highlight = highlightBldr.result().headOption.map(_._2).getOrElse("")
+          lstB += Hit(docId, score, fieldBldr.result(), highlight)
         }
         SearchSuccess(lstB.result())
     }

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
@@ -18,6 +18,7 @@ package pink.cozydev.protosearch
 
 import pink.cozydev.protosearch.highlight.FirstMatchHighlighter
 import pink.cozydev.protosearch.highlight.FragmentFormatter
+import pink.cozydev.protosearch.internal.IndexSearcher
 
 final case class SearchInterpreter(
     multiIndex: MultiIndex,

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pink.cozydev.protosearch
 
 import pink.cozydev.protosearch.highlight.FirstMatchHighlighter

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
@@ -36,7 +36,7 @@ final case class SearchInterpreter(
       parseQ.flatMap(q =>
         indexSearcher
           .search(q)
-          .flatMap(ds => scorer.score(q, ds))
+          .flatMap(ds => scorer.score(q, ds, request.size))
       )
 
     val lstB = List.newBuilder[Hit]

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
@@ -1,0 +1,58 @@
+package pink.cozydev.protosearch
+
+import pink.cozydev.protosearch.highlight.FirstMatchHighlighter
+import pink.cozydev.protosearch.highlight.FragmentFormatter
+
+final case class SearchInterpreter(
+    multiIndex: MultiIndex,
+    highlighter: FirstMatchHighlighter,
+) {
+  private val indexSearcher = IndexSearcher(multiIndex, multiIndex.schema.defaultOR)
+  private val scorer = Scorer(multiIndex, multiIndex.schema.defaultOR)
+  private val queryAnalyzer = multiIndex.schema.queryAnalyzer(multiIndex.schema.defaultField)
+
+  def search(request: SearchRequest): SearchResult = {
+    val parseQ = queryAnalyzer
+      .parse(request.query)
+      .map(q => if (request.lastTermPrefix) q.mapLastTerm(LastTermRewrite.termToPrefix) else q)
+    // TODO push down request size
+    val getDocs: Either[String, List[(Int, Double)]] =
+      parseQ.flatMap(q =>
+        indexSearcher
+          .search(q)
+          .flatMap(ds => scorer.score(q, ds))
+      )
+
+    val lstB = List.newBuilder[Hit]
+    lstB.sizeHint(request.size)
+    getDocs match {
+      case Left(err) => SearchFailure(err)
+      case Right(docs) =>
+        docs.foreach { case (docId, score) =>
+          val fieldBldr = Map.newBuilder[String, String]
+          request.resultFields.foreach(f =>
+            multiIndex.fields.get(f).foreach(arr => fieldBldr += f -> arr(docId))
+          )
+          val highlightBldr = Map.newBuilder[String, String]
+          request.highlightFields.foreach { hf =>
+            val field = multiIndex.fields.get(hf)
+            field.foreach { arr =>
+              val h = highlighter.highlight(arr(docId), request.query)
+              highlightBldr += hf -> h
+            }
+          }
+
+          // TODO Update Hit highlight to be Map
+          lstB += Hit(docId, score, fieldBldr.result(), highlightBldr.result().head._2)
+        }
+        SearchSuccess(lstB.result())
+    }
+  }
+}
+object SearchInterpreter {
+  private val defaultHighlighter =
+    FirstMatchHighlighter(FragmentFormatter(100, "<b>", "</b>"))
+
+  def default(index: MultiIndex): SearchInterpreter =
+    SearchInterpreter(index, defaultHighlighter)
+}

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchInterpreter.scala
@@ -59,8 +59,8 @@ final case class SearchInterpreter(
           }
 
           // TODO Update Hit highlight to be Map
-          val highlight = highlightBldr.result().headOption.map(_._2).getOrElse("")
-          lstB += Hit(docId, score, fieldBldr.result(), highlight)
+          val highlights = highlightBldr.result()
+          lstB += Hit(docId, score, fieldBldr.result(), highlights)
         }
         SearchSuccess(lstB.result())
     }

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchRequest.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchRequest.scala
@@ -1,0 +1,16 @@
+package pink.cozydev.protosearch
+
+final case class SearchRequest(
+    query: String,
+    size: Int,
+    highlightFields: List[String],
+    resultFields: List[String],
+    lastTermPrefix: Boolean,
+    // sort
+    // query re-writing?
+)
+object SearchRequest {
+  private val defaultSize = 10
+  def default(query: String): SearchRequest =
+    SearchRequest(query, defaultSize, Nil, Nil, false)
+}

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchRequest.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchRequest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pink.cozydev.protosearch
 
 final case class SearchRequest(

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchResult.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchResult.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pink.cozydev.protosearch
 
 sealed trait SearchResult {

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchResult.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchResult.scala
@@ -21,6 +21,11 @@ sealed trait SearchResult {
     case SearchFailure(msg) => fail(msg)
     case SearchSuccess(hits) => success(hits)
   }
+
+  def toEither: Either[String, List[Hit]] = this match {
+    case SearchFailure(msg) => Left(msg)
+    case SearchSuccess(hits) => Right(hits)
+  }
 }
 final case class SearchFailure(msg: String) extends SearchResult
 final case class SearchSuccess(hits: List[Hit]) extends SearchResult

--- a/core/src/main/scala/pink/cozydev/protosearch/SearchResult.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/SearchResult.scala
@@ -1,0 +1,10 @@
+package pink.cozydev.protosearch
+
+sealed trait SearchResult {
+  def fold[A](fail: String => A, success: List[Hit] => A): A = this match {
+    case SearchFailure(msg) => fail(msg)
+    case SearchSuccess(hits) => success(hits)
+  }
+}
+final case class SearchFailure(msg: String) extends SearchResult
+final case class SearchSuccess(hits: List[Hit]) extends SearchResult

--- a/core/src/main/scala/pink/cozydev/protosearch/Searcher.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/Searcher.scala
@@ -20,7 +20,7 @@ import pink.cozydev.protosearch.highlight.FirstMatchHighlighter
 import pink.cozydev.protosearch.highlight.FragmentFormatter
 import pink.cozydev.protosearch.internal.IndexSearcher
 
-final case class SearchInterpreter(
+final case class Searcher(
     multiIndex: MultiIndex,
     highlighter: FirstMatchHighlighter,
 ) {
@@ -64,10 +64,10 @@ final case class SearchInterpreter(
     }
   }
 }
-object SearchInterpreter {
+object Searcher {
   private val defaultHighlighter =
     FirstMatchHighlighter(FragmentFormatter(100, "<b>", "</b>"))
 
-  def default(index: MultiIndex): SearchInterpreter =
-    SearchInterpreter(index, defaultHighlighter)
+  def default(index: MultiIndex): Searcher =
+    Searcher(index, defaultHighlighter)
 }

--- a/core/src/main/scala/pink/cozydev/protosearch/analysis/QueryAnalyzer.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/analysis/QueryAnalyzer.scala
@@ -23,7 +23,7 @@ import pink.cozydev.lucille.QueryParser
 // TODO This is a hack, the Lucille parser tokenizes on white space only currently
 // We perhaps want Lucille to use a tokenizer from textmogrify
 // In the meantime, we rewrite the Query with our `Analyzer`
-case class QueryAnalyzer(
+final case class QueryAnalyzer(
     defaultField: String,
     analyzers: Map[String, Analyzer],
 ) {

--- a/core/src/main/scala/pink/cozydev/protosearch/internal/IndexSearcher.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/internal/IndexSearcher.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package pink.cozydev.protosearch
+package pink.cozydev.protosearch.internal
 
 import cats.data.NonEmptyList
 import pink.cozydev.lucille.{Query, TermQuery}
-import pink.cozydev.protosearch.internal.PositionalIter
+import pink.cozydev.protosearch._
 
 import java.util.regex.PatternSyntaxException
 

--- a/core/src/test/scala/pink/cozydev/protosearch/FrequencyIndexSearcherSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/FrequencyIndexSearcherSuite.scala
@@ -18,6 +18,7 @@ package pink.cozydev.protosearch
 
 import pink.cozydev.protosearch.analysis.Analyzer
 import pink.cozydev.lucille.QueryParser
+import internal.IndexSearcher
 
 class FrequencyIndexSearcherSuite extends munit.FunSuite {
 

--- a/core/src/test/scala/pink/cozydev/protosearch/PositionalIndexSearcherSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/PositionalIndexSearcherSuite.scala
@@ -18,6 +18,7 @@ package pink.cozydev.protosearch
 
 import pink.cozydev.protosearch.analysis.Analyzer
 import pink.cozydev.lucille.QueryParser
+import internal.IndexSearcher
 
 class PositionalIndexSearcherSuite extends munit.FunSuite {
 

--- a/core/src/test/scala/pink/cozydev/protosearch/ScorerSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/ScorerSuite.scala
@@ -38,7 +38,7 @@ class ScorerSuite extends munit.FunSuite {
   def score(q: String, docs: Set[Int]): Either[String, List[(Int, Double)]] =
     QueryParser
       .parse(q)
-      .flatMap(q => scorer.score(q, docs))
+      .flatMap(q => scorer.score(q, docs, 10))
 
   def ordered(hits: Either[String, List[(Int, Double)]]): List[Int] =
     hits.fold(_ => Nil, ds => ds.map(_._1))
@@ -72,6 +72,18 @@ class ScorerSuite extends munit.FunSuite {
   test("scores phrase query") {
     val hits = score("\"Two Bad Mice\"", allDocs)
     assertEquals(ordered(hits), List(1))
+  }
+
+  test("scorer with topN=1 returns only top doc") {
+    val q = "Tale OR Two" // has 3 matches
+    val hits = QueryParser.parse(q).flatMap(q => scorer.score(q, allDocs, topN = 1))
+    assertEquals(ordered(hits), List(1))
+  }
+
+  test("scorer topN can be bigger than number of matches") {
+    val q = "Tale OR Two" // has 3 matches
+    val hits = QueryParser.parse(q).flatMap(q => scorer.score(q, allDocs, topN = 999))
+    assertEquals(ordered(hits), List(1, 0, 2))
   }
 
 }

--- a/core/src/test/scala/pink/cozydev/protosearch/SearcherSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/SearcherSuite.scala
@@ -19,7 +19,7 @@ package pink.cozydev.protosearch
 import pink.cozydev.protosearch.analysis.{Analyzer, QueryAnalyzer}
 import fixtures.BookIndex
 
-class SearchInterpreterSuite extends munit.FunSuite {
+class SearcherSuite extends munit.FunSuite {
   import BookIndex._
 
   val analyzer = Analyzer.default.withLowerCasing
@@ -32,7 +32,7 @@ class SearchInterpreterSuite extends munit.FunSuite {
 
   val qAnalyzer = QueryAnalyzer("title", ("title", analyzer), ("author", analyzer))
 
-  val searcher = SearchInterpreter.default(index)
+  val searcher = Searcher.default(index)
 
   def search(q: String): Either[String, List[Book]] = {
     val req = SearchRequest.default(q)

--- a/core/src/test/scala/pink/cozydev/protosearch/WriteReadLoopSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/WriteReadLoopSuite.scala
@@ -35,8 +35,10 @@ class WriteReadLoopSuite extends munit.FunSuite {
     val indexBytes = MultiIndex.codec.encode(index).map(_.bytes)
 
     def search(index: MultiIndex)(qs: String): Either[String, List[Book]] = {
-      val result = index.search(qs)
-      result.map(hits => hits.map(h => allBooks(h.id)))
+      val searcher = SearchInterpreter.default(index)
+      val req = SearchRequest.default(qs)
+      val result = searcher.search(req)
+      result.toEither.map(hits => hits.map(h => allBooks(h.id)))
     }
 
     val indexRead = indexBytes

--- a/core/src/test/scala/pink/cozydev/protosearch/WriteReadLoopSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/WriteReadLoopSuite.scala
@@ -35,7 +35,7 @@ class WriteReadLoopSuite extends munit.FunSuite {
     val indexBytes = MultiIndex.codec.encode(index).map(_.bytes)
 
     def search(index: MultiIndex)(qs: String): Either[String, List[Book]] = {
-      val searcher = SearchInterpreter.default(index)
+      val searcher = Searcher.default(index)
       val req = SearchRequest.default(qs)
       val result = searcher.search(req)
       result.toEither.map(hits => hits.map(h => allBooks(h.id)))

--- a/docs/02-tutorial/01-indexing.md
+++ b/docs/02-tutorial/01-indexing.md
@@ -38,17 +38,4 @@ And then we can finally index our `books` using the builder:
 val index = indexBldr.fromList(books)
 ```
 
-Finally we'll then need a `search` function to test out.
-We use a `queryAnalyzer` with the same default field here to make sure our queries get the same analysis as our documents did at indexing time.
-
-
-```scala mdoc:silent
-val qAnalyzer = index.queryAnalyzer
-
-def search(q: String): List[Book] =
-  index.search(q)
-    .map(hits => hits.map(h => books(h.id)))
-    .fold(_ => Nil, identity)
-```
-
-Now we can use our `search` function to explore some different query types!
+To learn how to search our `index`, jump over to the [querying tutorial][Querying].

--- a/docs/02-tutorial/02-querying.md
+++ b/docs/02-tutorial/02-querying.md
@@ -23,12 +23,12 @@ val index = IndexBuilder.of[Book](
 
 ## Searching
 
-In order to search our index with various queries we need to setup a `SearchInterpreter`.
+In order to search our index with various queries we need to setup a `Searcher`.
 
 ```scala mdoc:silent
-import pink.cozydev.protosearch.SearchInterpreter
+import pink.cozydev.protosearch.Searcher
 
-val searcher = SearchInterpreter.default(index)
+val searcher = Searcher.default(index)
 ```
 
 And now we can define our search function

--- a/docs/02-tutorial/02-querying.md
+++ b/docs/02-tutorial/02-querying.md
@@ -19,11 +19,30 @@ val index = IndexBuilder.of[Book](
   (Field("title", analyzer, stored=true, indexed=true, positions=true), _.title),
   (Field("author", analyzer, stored=true, indexed=true, positions=false), _.author),
 ).fromList(books)
+```
 
-def search(q: String): List[Book] =
-  index.search(q)
-    .map(hits => hits.map(h => books(h.id)))
-    .fold(_ => Nil, identity)
+## Searching
+
+In order to search our index with various queries we need to setup a `SearchInterpreter`.
+
+```scala mdoc:silent
+import pink.cozydev.protosearch.SearchInterpreter
+
+val searcher = SearchInterpreter.default(index)
+```
+
+And now we can define our search function
+
+```scala mdoc:silent
+import pink.cozydev.protosearch.{SearchFailure, SearchRequest, SearchSuccess}
+
+def search(q: String): List[Book] = {
+  val req = SearchRequest.default(q)
+  searcher.search(req) match {
+    case SearchFailure(_) => Nil
+    case SearchSuccess(hits) => hits.map(h => books(h.id))
+  }
+}
 ```
 
 Now we can use our `search` function to explore some different query types!

--- a/jsinterop/src/main/scala/pink/cozydev/protosearch/JsInterop.scala
+++ b/jsinterop/src/main/scala/pink/cozydev/protosearch/JsInterop.scala
@@ -16,6 +16,7 @@
 
 package pink.cozydev.protosearch
 
+import pink.cozydev.protosearch.highlight.{FirstMatchHighlighter, FragmentFormatter}
 import scala.scalajs.js.annotation._
 import scala.scalajs.js
 import org.scalajs.dom.Blob
@@ -32,8 +33,10 @@ class JsHit(
 @JSExportTopLevel("Querier")
 class Querier(val mIndex: MultiIndex) {
   import js.JSConverters._
-  val searcher = SearchInterpreter.default(mIndex)
-  val highlightFields = List("body")
+  val highlighter =
+    FirstMatchHighlighter(FragmentFormatter(150, "<mark>", "</mark>"))
+  val searcher = SearchInterpreter(mIndex, highlighter)
+  val highlightFields = List("title", "body")
   val resultFields = List("body", "path", "title")
 
   @JSExport

--- a/jsinterop/src/main/scala/pink/cozydev/protosearch/JsInterop.scala
+++ b/jsinterop/src/main/scala/pink/cozydev/protosearch/JsInterop.scala
@@ -26,7 +26,7 @@ class JsHit(
     val id: Int,
     val score: Double,
     val fields: js.Dictionary[String],
-    val highlight: String,
+    val highlights: js.Dictionary[String],
 ) extends js.Object
 
 @JSExportTopLevel("Querier")
@@ -45,7 +45,7 @@ class Querier(val mIndex: MultiIndex) {
         err => { println(err); Nil },
         identity,
       )
-      .map(h => new JsHit(h.id, h.score, h.fields.toJSDictionary, h.highlight))
+      .map(h => new JsHit(h.id, h.score, h.fields.toJSDictionary, h.highlights.toJSDictionary))
     hits.toJSArray
   }
 }

--- a/jsinterop/src/main/scala/pink/cozydev/protosearch/JsInterop.scala
+++ b/jsinterop/src/main/scala/pink/cozydev/protosearch/JsInterop.scala
@@ -35,7 +35,7 @@ class Querier(val mIndex: MultiIndex) {
   import js.JSConverters._
   val highlighter =
     FirstMatchHighlighter(FragmentFormatter(150, "<mark>", "</mark>"))
-  val searcher = SearchInterpreter(mIndex, highlighter)
+  val searcher = Searcher(mIndex, highlighter)
   val highlightFields = List("title", "body")
   val resultFields = List("body", "path", "title")
 

--- a/jsinterop/src/main/scala/pink/cozydev/protosearch/JsInterop.scala
+++ b/jsinterop/src/main/scala/pink/cozydev/protosearch/JsInterop.scala
@@ -41,7 +41,7 @@ class Querier(val mIndex: MultiIndex) {
 
   @JSExport
   def search(query: String): js.Array[JsHit] = {
-    val req = SearchRequest(query, 10, highlightFields, resultFields, true)
+    val req = SearchRequest(query, size = 10, highlightFields, resultFields, lastTermPrefix = true)
     val hits = searcher
       .search(req)
       .fold(

--- a/jsinterop/src/main/scala/pink/cozydev/protosearch/JsInterop.scala
+++ b/jsinterop/src/main/scala/pink/cozydev/protosearch/JsInterop.scala
@@ -32,11 +32,15 @@ class JsHit(
 @JSExportTopLevel("Querier")
 class Querier(val mIndex: MultiIndex) {
   import js.JSConverters._
+  val searcher = SearchInterpreter.default(mIndex)
+  val highlightFields = List("body")
+  val resultFields = List("body", "path", "title")
 
   @JSExport
   def search(query: String): js.Array[JsHit] = {
-    val hits = mIndex
-      .searchInteractive(query)
+    val req = SearchRequest(query, 10, highlightFields, resultFields, true)
+    val hits = searcher
+      .search(req)
       .fold(
         err => { println(err); Nil },
         identity,

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.css
@@ -65,6 +65,15 @@
   color: var(--secondary-color);
 }
 
+.search-modal-content .title mark {
+  color: var(--secondary-color);
+  background-color: var(--syntax-wheel3);
+}
+
+.search-modal-content mark {
+  background-color: var(--syntax-wheel3);
+}
+
 /* The Close Button */
 .search-close {
   float: right;

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.js
@@ -2,7 +2,7 @@ function renderDoc(hit) {
   const path = hit.fields.path
   const link = "../" + hit.fields.path.replace(".txt", ".html")
   const title = hit.fields.title
-  const preview = hit.highlight
+  const preview = hit.highlights["body"]
   return (
 `
 <ol>

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.js
@@ -1,7 +1,7 @@
 function renderDoc(hit) {
   const path = hit.fields.path
   const link = "../" + hit.fields.path.replace(".txt", ".html")
-  const title = hit.fields.title
+  const title = hit.highlights["title"] || hit.fields["title"]
   const preview = hit.highlights["body"]
   return (
 `

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
@@ -3,7 +3,7 @@ function render(hit) {
   const htmlPath = hit.fields.path.replace(".txt", ".html")
   const link = new URL("../" + htmlPath, baseUrl)
   const title = hit.fields.title
-  const preview = hit.highlight
+  const preview = hit.highlights["body"]
   return (
 `
 <ol>

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
@@ -2,7 +2,7 @@ function render(hit) {
   const path = hit.fields.path
   const htmlPath = hit.fields.path.replace(".txt", ".html")
   const link = new URL("../" + htmlPath, baseUrl)
-  const title = hit.fields.title
+  const title = hit.highlights["title"] || hit.fields["title"]
   const preview = hit.highlights["body"]
   return (
 `

--- a/scaladoc/src/test/scala/pink/cozydev/protosearch/scaladoc/ScaladocSuite.scala
+++ b/scaladoc/src/test/scala/pink/cozydev/protosearch/scaladoc/ScaladocSuite.scala
@@ -16,7 +16,7 @@
 
 package pink.cozydev.protosearch.scaladoc
 import munit.FunSuite
-import pink.cozydev.protosearch.{SearchInterpreter, SearchRequest}
+import pink.cozydev.protosearch.{Searcher, SearchRequest}
 
 class ScaladocSuite extends FunSuite {
 
@@ -119,7 +119,7 @@ final case class IndexBuilder[A] private (
   def searchScaladoc(source: String, queries: List[String]): List[ScaladocInfo] = {
     val scaladocInfoList = ParseScaladoc.parseAndExtractInfo(source)
     val index = ScaladocIndexer.indexBuilder.fromList(scaladocInfoList)
-    val searcher = SearchInterpreter.default(index)
+    val searcher = Searcher.default(index)
     def search(q: String): List[ScaladocInfo] = {
       val req = SearchRequest.default(q)
       val searchResults = searcher.search(req)

--- a/scaladoc/src/test/scala/pink/cozydev/protosearch/scaladoc/ScaladocSuite.scala
+++ b/scaladoc/src/test/scala/pink/cozydev/protosearch/scaladoc/ScaladocSuite.scala
@@ -16,6 +16,7 @@
 
 package pink.cozydev.protosearch.scaladoc
 import munit.FunSuite
+import pink.cozydev.protosearch.{SearchInterpreter, SearchRequest}
 
 class ScaladocSuite extends FunSuite {
 
@@ -118,8 +119,10 @@ final case class IndexBuilder[A] private (
   def searchScaladoc(source: String, queries: List[String]): List[ScaladocInfo] = {
     val scaladocInfoList = ParseScaladoc.parseAndExtractInfo(source)
     val index = ScaladocIndexer.indexBuilder.fromList(scaladocInfoList)
+    val searcher = SearchInterpreter.default(index)
     def search(q: String): List[ScaladocInfo] = {
-      val searchResults = index.search(q)
+      val req = SearchRequest.default(q)
+      val searchResults = searcher.search(req)
       searchResults.fold(_ => Nil, hits => hits.map(h => scaladocInfoList.toList(h.id)))
     }
 


### PR DESCRIPTION
This PR moves all of the searching logic into a new `Searcher` class whose `search` method takes a `SearchRequest`.
A `SearchRequest` includes the query in addition to the desired number of documents, the stored fields to retrieve, the fields to highlight, and whether or not the last term of the query should be rewritten as a prefix.

This clean up removed hard coded highlighting logic from `MultiIndex` and enables highlighting multiple fields.

![image](https://github.com/user-attachments/assets/72911a0d-0e04-4292-8f3d-747620532d56)
