### PR TITLE
Fix linking to versioned pages

### DIFF
--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
@@ -1,6 +1,6 @@
 function render(hit) {
   const path = hit.fields.path
-  const htmlPath = hit.fields.path.replace(".txt", ".html")
+  const htmlPath = `${path}.html`
   const link = new URL("../" + htmlPath, baseUrl)
   const title = hit.highlights["title"] || hit.fields["title"]
   const preview = hit.highlights["body"]

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
@@ -1,7 +1,7 @@
 function render(hit) {
   const path = hit.fields.path
   const htmlPath = `${path}.html`
-  const link = new URL("../" + htmlPath, baseUrl)
+  const link = new URL(htmlPath, baseUrl)
   const title = hit.highlights["title"] || hit.fields["title"]
   const preview = hit.highlights["body"]
   return (
@@ -46,7 +46,7 @@ async function main() {
   }
 
   // Setup the search worker, it returns inner html to the modal
-  const worker = new Worker(new URL("searchBarWorker.js", baseUrl))
+  const worker = new Worker(new URL("search/searchBarWorker.js", baseUrl))
   worker.onmessage = function(e) {
     const markup = e.data.map(render).join("\n")
     modalBody.innerHTML = markup
@@ -72,7 +72,7 @@ async function main() {
 }
 
 // Only run once page has finished loading
-const baseUrl = document.currentScript.src
+const baseUrl = new URL("../", document.currentScript.src)
 window.onload = function() {
   main()
 }

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/IndexFormat.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/IndexFormat.scala
@@ -28,8 +28,6 @@ import laika.theme.Theme
 import java.io.OutputStream
 import pink.cozydev.protosearch.{Field, IndexBuilder, MultiIndex}
 import laika.io.model.RenderedDocument
-import laika.config.Versions
-import laika.config.LaikaKeys
 
 case object IndexFormat extends TwoPhaseRenderFormat[Formatter, BinaryPostProcessor.Builder] {
 
@@ -57,7 +55,7 @@ case object IndexFormat extends TwoPhaseRenderFormat[Formatter, BinaryPostProces
             .of[RenderedDocument](
               (Field("body", analyzer, true, true, true), _.content),
               (Field("title", analyzer, true, true, true), d => renderTitle(d.title, d.path)),
-              (Field("path", analyzer, true, true, false), d => renderLink(d)),
+              (Field("path", analyzer, true, true, false), d => renderPath(d)),
             )
             .fromList(result.allDocuments.toList)
 
@@ -87,21 +85,7 @@ case object IndexFormat extends TwoPhaseRenderFormat[Formatter, BinaryPostProces
       case None => path.name
     }
 
-  private def renderLink(doc: RenderedDocument): String = {
-    val isVersioned = doc.config
-      .get[Boolean](LaikaKeys.versioned)
-      .getOrElse(false)
-    val version = doc.config
-      .get[Versions]
-      .toOption
-      .map(v => v.currentVersion.pathSegment)
-      .getOrElse("")
-
-    val path = doc.asNavigationItem().link.map { l =>
-      val target = l.target.render().stripSuffix(".txt")
-      if (isVersioned) s"$version/$target" else target
-    }
-    path.getOrElse("")
-  }
+  private def renderPath(doc: RenderedDocument): String =
+    doc.path.withoutSuffix.toString
 
 }

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/analysis/PlaintextRenderer.scala
@@ -141,6 +141,10 @@ object PlaintextRenderer extends ((Formatter, Element) => String) {
 case object Plaintext extends RenderFormat[Formatter] {
   val fileSuffix = "txt"
 
+  // Override `RenderFormat#description` to "html" so that Laika's `PathTranslator` treats us like
+  // the html renderer, which supports versioning, and properly gives us versioned paths.
+  override val description: String = "html"
+
   val defaultRenderer: (Formatter, Element) => String =
     PlaintextRenderer
 

--- a/laikaIO/src/main/scala/pink/cozydev/protosearch/ui/SearchUI.scala
+++ b/laikaIO/src/main/scala/pink/cozydev/protosearch/ui/SearchUI.scala
@@ -21,12 +21,16 @@ import laika.ast.Path
 import laika.io.model.InputTree
 import laika.theme.{Theme, ThemeBuilder, ThemeProvider}
 import laika.helium.Helium
+import laika.api.config.ConfigBuilder
+import laika.config.LaikaKeys
 
 object SearchUI extends ThemeProvider {
 
   def build[F[_]: Async]: Resource[F, Theme[F]] = {
 
     val path = "pink/cozydev/protosearch/sbt"
+
+    val unversioned = ConfigBuilder.empty.withValue(LaikaKeys.versioned, false).build
 
     val inputs = InputTree[F]
       .addClassLoaderResource(
@@ -57,6 +61,7 @@ object SearchUI extends ThemeProvider {
         s"$path/search.css",
         Path.Root / "search" / "search.css",
       )
+      .addConfig(unversioned, Path.Root / "search")
       .addClassLoaderResource(
         s"$path/topNav.template.html",
         Path.Root / "helium" / "templates" / "topNav.template.html",

--- a/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/IndexFormatSuite.scala
+++ b/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/IndexFormatSuite.scala
@@ -79,13 +79,13 @@ class IndexFormatSuite extends CatsEffectSuite {
     assertIO(title, Some(List("The Title hasSpan")))
   }
 
-  test("stores path field") {
+  test("stores path field without .txt suffix") {
     val doc =
       """|# The Title
          |normal **bold** *italics* `code`
          |""".stripMargin
     val path = renderIndex(doc).map(idx => idx.fields.get("path").map(_.toList))
-    assertIO(path, Some(List("client/doc.txt")))
+    assertIO(path, Some(List("client/doc")))
   }
 
 }

--- a/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/IndexFormatSuite.scala
+++ b/laikaIO/src/test/scala/pink/cozydev/protosearch/analysis/IndexFormatSuite.scala
@@ -22,13 +22,14 @@ import cats.effect.IO
 import cats.effect.kernel.Resource
 import laika.api.Transformer
 import laika.ast.Path
-import laika.config.SyntaxHighlighting
+import laika.config.{LaikaKeys, SyntaxHighlighting, Version, Versions}
 import laika.format.Markdown
 import laika.io.api.BinaryTreeTransformer
 import laika.io.model.InputTree
 import laika.io.syntax.*
 import munit.CatsEffectSuite
 import scodec.bits.ByteVector
+import laika.api.config.ConfigBuilder
 
 class IndexFormatSuite extends CatsEffectSuite {
 
@@ -40,8 +41,16 @@ class IndexFormatSuite extends CatsEffectSuite {
       .parallel[IO]
       .build
 
-  def renderIndex(str: String): IO[MultiIndex] = {
-    val tree = InputTree[IO].addString(str, Path.Root / "client" / "doc.md")
+  val versioned = ConfigBuilder.empty
+    .withValue(LaikaKeys.versioned, true)
+    .withValue(LaikaKeys.versions, Versions.forCurrentVersion(Version("latest", "v1.0")))
+    .build
+  val unversioned = ConfigBuilder.empty.withValue(LaikaKeys.versioned, false).build
+
+  def renderIndex(str: String, isVersioned: Boolean = false): IO[MultiIndex] = {
+    val dir = Path.Root / "client"
+    val base = InputTree[IO].addString(str, dir / "doc.md")
+    val tree = if (isVersioned) base.addConfig(versioned, dir) else base.addConfig(unversioned, dir)
     val bytes = fs2.io
       .readOutputStream[IO](1024)(out =>
         transformer.use(_.fromInput(tree).toStream(IO(out)).transform)
@@ -79,13 +88,23 @@ class IndexFormatSuite extends CatsEffectSuite {
     assertIO(title, Some(List("The Title hasSpan")))
   }
 
-  test("stores path field without .txt suffix") {
+  test("stores unversioned path field without .txt suffix") {
     val doc =
       """|# The Title
          |normal **bold** *italics* `code`
          |""".stripMargin
-    val path = renderIndex(doc).map(idx => idx.fields.get("path").map(_.toList))
+    val path =
+      renderIndex(doc, isVersioned = false).map(idx => idx.fields.get("path").map(_.toList))
     assertIO(path, Some(List("client/doc")))
+  }
+
+  test("stores versioned path field without .txt suffix") {
+    val doc =
+      """|# The Title
+         |normal **bold** *italics* `code`
+         |""".stripMargin
+    val path = renderIndex(doc, isVersioned = true).map(idx => idx.fields.get("path").map(_.toList))
+    assertIO(path, Some(List("v1.0/client/doc")))
   }
 
 }


### PR DESCRIPTION
This PR changes a couple things:
- We remove the `.txt` when constructing the index, this suffix was added by us in the `PlaintextRenderer` and doesn't make sense elsewhere
- We force the `/search` directory that we make with all our js/css/html files to be unversioned so it is always at `/search`.
  - Previously this directory would end up in `/latest/search` for Laika and `/search` for http4s because without us explicitly setting whether or not it is versioned, it inherits from `Root` which is different between these two project.
- ~When building the index, if a page is versioned we prepend the `path` with it's current version path segment.~
- Set `description = "html"` in `PlaintextRenderer` to support versioning in `PathTranslator`
  - this way we can simply use `RenderedDocument#path` when building the index.

Closes https://github.com/cozydev-pink/protosearch/issues/162