### PR TITLE
Make path relative to document root

### DIFF
--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/searchBar.js
@@ -1,5 +1,6 @@
 function render(hit) {
-  const path = hit.fields.path
+  // Check if the path has a leading slash, if so, remove it
+  const path = hit.fields.path.startsWith("/") ? hit.fields.path.slice(1) : hit.fields.path
   const htmlPath = `${path}.html`
   const link = new URL(htmlPath, baseUrl)
   const title = hit.highlights["title"] || hit.fields["title"]


### PR DESCRIPTION
`path` has a leading `/` which makes it an absolute link, we want it to be a relative link.

This should fix links when hosting on GH pages under a path like:
https://cozydev-pink.github.io/Laika/latest/01-about-laika/01-features.html