### PR TITLE
Trim whitespace from query when highlighting

### DIFF
--- a/core/src/main/scala/pink/cozydev/protosearch/highlight/FirstMatchHighlighter.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/highlight/FirstMatchHighlighter.scala
@@ -31,16 +31,17 @@ case class FirstMatchHighlighter(
 
   def highlight(str: String, queryStr: String): String = {
     // lowercase both in place, to find case-insensitive matches
-    val offset = str.toLowerCase().indexOf(queryStr.toLowerCase())
+    val normalizedQ = queryStr.trim().toLowerCase()
+    val offset = str.toLowerCase().indexOf(normalizedQ)
     if (offset == -1)
-      // 'queryStr' does not appear in 'str'
+      // 'normalizedQ' does not appear in 'str'
       trim(str)
     else {
       val start = Math.max(0, offset - lookBackWindowSize)
       if (start == 0 || str.size < formatter.maxSize) {
         // First match 'offset' is within first 'lookBackWindowSize' characters,
         // or the whole 'str' is within formatter max, no slicing necessary.
-        val fStr = formatter.format(str, List(offset, queryStr.size))
+        val fStr = formatter.format(str, List(offset, normalizedQ.size))
         trim(fStr)
       } else {
         // First match 'offset' not within first 'lookBackWindowSize' characters,
@@ -48,7 +49,7 @@ case class FirstMatchHighlighter(
         val nearby = str.indexWhere(c => " \n\t.".contains(c), start)
         val slice = str.drop(nearby)
         val newOffset = offset - nearby
-        val fStr = formatter.format(slice, List(newOffset, queryStr.size))
+        val fStr = formatter.format(slice, List(newOffset, normalizedQ.size))
         trim(fStr)
       }
     }

--- a/core/src/test/scala/pink/cozydev/protosearch/highlight/FirstMatchHighlighterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/highlight/FirstMatchHighlighterSuite.scala
@@ -34,6 +34,20 @@ class FirstMatchHighlighterSuite extends munit.FunSuite {
     assertEquals(actual, expected)
   }
 
+  test("highlights simple substring, ignoring trailing whitespace in query") {
+    val s = "hello world"
+    val actual = highlighter.highlight(s, "world ")
+    val expected = "hello <b>world</b>"
+    assertEquals(actual, expected)
+  }
+
+  test("highlights simple substring, ignoring leading whitespace in query") {
+    val s = "hello world"
+    val actual = highlighter.highlight(s, " world")
+    val expected = "hello <b>world</b>"
+    assertEquals(actual, expected)
+  }
+
   test("highlights substring with different casing") {
     val s = "hello world"
     val actual = highlighter.highlight(s, "WoRlD")


### PR DESCRIPTION
This PR changes the FirstMatchHighlighter to trim whitespace from the queryStr so adding a space at the end of a query doesn't break highlighting.

Before - no trailing space
![protosearch-highlight-ws1](https://github.com/user-attachments/assets/37314599-70f9-4e9a-8dd5-9e35fdd83760)

Before - trailing space
![protosearch-highlight-ws2](https://github.com/user-attachments/assets/1eb1d469-6118-43c2-8b53-89925a541a3a)

After - trailing space
![protosearch-highlight-ws3](https://github.com/user-attachments/assets/32f4249c-b801-4ca7-80ac-71a3176143d0)
