### PR TITLE
Change docIds to start at 1 not 0

### DIFF
--- a/core/src/main/scala/pink/cozydev/protosearch/FrequencyIndex.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/FrequencyIndex.scala
@@ -103,7 +103,7 @@ object FrequencyIndex {
 
   def apply(docs: Iterable[Iterable[String]]): FrequencyIndex = {
     val termPostingsMap = new MMap[String, FrequencyPostingsBuilder].empty
-    var docId = 0
+    var docId = 1 // docIds start at 1 so iters can start at 0
     docs.foreach { doc =>
       doc.foreach { term =>
         termPostingsMap

--- a/core/src/main/scala/pink/cozydev/protosearch/PositionalIndex.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/PositionalIndex.scala
@@ -102,7 +102,7 @@ object PositionalIndex {
 
   def apply(docs: Iterable[Iterable[String]]): PositionalIndex = {
     val termPostingsMap = new MMap[String, PositionalPostingsBuilder].empty
-    var docId = 0
+    var docId = 1 // docIds start at 1 so iterators can start at 0
     docs.foreach { doc =>
       var position = 0
       doc.foreach { term =>
@@ -122,7 +122,7 @@ object PositionalIndex {
       keys += k
       values += v.toPositionalPostingsList
     }
-    new PositionalIndex(new TermDictionary(keys.result()), values.result(), docId) {}
+    new PositionalIndex(new TermDictionary(keys.result()), values.result(), docId - 1) {}
   }
 
   val codec: Codec[PositionalIndex] = {

--- a/core/src/main/scala/pink/cozydev/protosearch/Searcher.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/Searcher.scala
@@ -45,15 +45,16 @@ final case class Searcher(
       case Left(err) => SearchFailure(err)
       case Right(docs) =>
         docs.foreach { case (docId, score) =>
+          val docOffset = docId - 1 // Because docIds start at 1, not 0
           val fieldBldr = Map.newBuilder[String, String]
           request.resultFields.foreach(f =>
-            multiIndex.fields.get(f).foreach(arr => fieldBldr += f -> arr(docId))
+            multiIndex.fields.get(f).foreach(arr => fieldBldr += f -> arr(docOffset))
           )
           val highlightBldr = Map.newBuilder[String, String]
           request.highlightFields.foreach { hf =>
             val field = multiIndex.fields.get(hf)
             field.foreach { arr =>
-              val h = highlighter.highlight(arr(docId), request.query)
+              val h = highlighter.highlight(arr(docOffset), request.query)
               highlightBldr += hf -> h
             }
           }

--- a/core/src/main/scala/pink/cozydev/protosearch/internal/IndexSearcher.scala
+++ b/core/src/main/scala/pink/cozydev/protosearch/internal/IndexSearcher.scala
@@ -38,7 +38,7 @@ object IndexSearcher {
   private class MultiIndexSearcher(index: MultiIndex, defaultOR: Boolean) extends IndexSearcher {
 
     private val defaultIndex = index.indexes(index.schema.defaultField)
-    private lazy val allDocs: Set[Int] = Range(0, defaultIndex.numDocs).toSet
+    private lazy val allDocs: Set[Int] = Range(1, defaultIndex.numDocs + 1).toSet
     private val defaultCombine =
       if (defaultOR)
         (sets: NonEmptyList[Set[Int]]) => IndexSearcher.unionSets(sets)
@@ -69,7 +69,7 @@ object IndexSearcher {
 
   private class SingleIndexSearcher(index: Index, defaultOR: Boolean) extends IndexSearcher {
 
-    private lazy val allDocs: Set[Int] = Range(0, index.numDocs).toSet
+    private lazy val allDocs: Set[Int] = Range(1, index.numDocs + 1).toSet
     private val defaultCombine =
       if (defaultOR)
         (sets: NonEmptyList[Set[Int]]) => IndexSearcher.unionSets(sets)

--- a/core/src/test/scala/pink/cozydev/protosearch/FrequencyIndexSearcherSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/FrequencyIndexSearcherSuite.scala
@@ -34,7 +34,7 @@ class FrequencyIndexSearcherSuite extends munit.FunSuite {
     val q = search("fast")
     assertEquals(
       q,
-      Right(Set(1)),
+      Right(Set(2)),
     )
   }
 
@@ -42,7 +42,7 @@ class FrequencyIndexSearcherSuite extends munit.FunSuite {
     val q = search("fast cat")
     assertEquals(
       q,
-      Right(Set(0, 1, 2)),
+      Right(Set(1, 2, 3)),
     )
   }
 
@@ -50,7 +50,7 @@ class FrequencyIndexSearcherSuite extends munit.FunSuite {
     val q = search("fast AND cat")
     assertEquals(
       q,
-      Right(Set(1)),
+      Right(Set(2)),
     )
   }
 
@@ -58,13 +58,13 @@ class FrequencyIndexSearcherSuite extends munit.FunSuite {
     val q = search("the AND fast AND cat")
     assertEquals(
       q,
-      Right(Set(1)),
+      Right(Set(2)),
     )
   }
 
   test("Or") {
     val q = search("fast OR cat")
-    val results = Set(0, 1, 2)
+    val results = Set(1, 2, 3)
     assertEquals(
       q,
       Right(results),
@@ -73,7 +73,7 @@ class FrequencyIndexSearcherSuite extends munit.FunSuite {
 
   test("Double Or") {
     val q = search("the OR fast OR cat")
-    val results = Set(0, 1, 2)
+    val results = Set(1, 2, 3)
     assertEquals(
       q,
       Right(results),
@@ -82,7 +82,7 @@ class FrequencyIndexSearcherSuite extends munit.FunSuite {
 
   test("cat AND (fast OR quick)") {
     val q = search("cat AND (fast OR quick)")
-    val results = Set(0, 1)
+    val results = Set(1, 2)
     assertEquals(
       q,
       Right(results),
@@ -91,7 +91,7 @@ class FrequencyIndexSearcherSuite extends munit.FunSuite {
 
   test("cat AND NOT fast") {
     val q = search("cat AND NOT fast")
-    val results = Set(0, 2)
+    val results = Set(1, 3)
     assertEquals(
       q,
       Right(results),
@@ -100,7 +100,7 @@ class FrequencyIndexSearcherSuite extends munit.FunSuite {
 
   test("[a TO z]") {
     val q = search("[a TO z]")
-    val results = Set(0, 1, 2)
+    val results = Set(1, 2, 3)
     assertEquals(
       q,
       Right(results),
@@ -109,7 +109,7 @@ class FrequencyIndexSearcherSuite extends munit.FunSuite {
 
   test("f*") {
     val q = search("f*")
-    val results = Set(0, 1)
+    val results = Set(1, 2)
     assertEquals(
       q,
       Right(results),
@@ -118,7 +118,7 @@ class FrequencyIndexSearcherSuite extends munit.FunSuite {
 
   test("sleeps*") {
     val q = search("sleeps*")
-    val results = Set(2)
+    val results = Set(3)
     assertEquals(
       q,
       Right(results),
@@ -127,7 +127,7 @@ class FrequencyIndexSearcherSuite extends munit.FunSuite {
 
   test("regex") {
     val q = search("/jump.*/ /cat/")
-    val results = Set(0, 1, 2)
+    val results = Set(1, 2, 3)
     assertEquals(
       q,
       Right(results),

--- a/core/src/test/scala/pink/cozydev/protosearch/IndexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/IndexSuite.scala
@@ -39,9 +39,9 @@ class IndexSuite extends munit.FunSuite {
   }
 
   test("docsWithTerm returns list of docIDs containing term") {
-    assertEquals(index.docsWithTerm("cat").toList.sorted, List(0, 1, 2))
-    assertEquals(index.docsWithTerm("the").toList.sorted, List(0, 1))
-    assertEquals(index.docsWithTerm("lazy").toList.sorted, List(0, 2))
+    assertEquals(index.docsWithTerm("cat").toList.sorted, List(1, 2, 3))
+    assertEquals(index.docsWithTerm("the").toList.sorted, List(1, 2))
+    assertEquals(index.docsWithTerm("lazy").toList.sorted, List(1, 3))
   }
 
   test("termIndexWhere returns zero when nonexistent would insert at beginning") {
@@ -55,11 +55,11 @@ class IndexSuite extends munit.FunSuite {
   }
 
   test("docsForPrefix returns set of docIDs containing prefixes") {
-    assertEquals(index.docsForPrefix("f").toSet, Set(0, 1))
+    assertEquals(index.docsForPrefix("f").toSet, Set(1, 2))
   }
 
   test("docsForPrefix returns set of docIDs containing exact term as prefix") {
-    assertEquals(index.docsForPrefix("sleeps").toSet, Set(2))
+    assertEquals(index.docsForPrefix("sleeps").toSet, Set(3))
   }
 
   test("docsForPrefix returns empty set when no docs contain prefix") {

--- a/core/src/test/scala/pink/cozydev/protosearch/PositionalIndexSearcherSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/PositionalIndexSearcherSuite.scala
@@ -34,7 +34,7 @@ class PositionalIndexSearcherSuite extends munit.FunSuite {
     val q = search("fast")
     assertEquals(
       q,
-      Right(Set(1)),
+      Right(Set(2)),
     )
   }
 
@@ -42,7 +42,7 @@ class PositionalIndexSearcherSuite extends munit.FunSuite {
     val q = search("fast cat")
     assertEquals(
       q,
-      Right(Set(0, 1, 2)),
+      Right(Set(1, 2, 3)),
     )
   }
 
@@ -50,7 +50,7 @@ class PositionalIndexSearcherSuite extends munit.FunSuite {
     val q = search("fast AND cat")
     assertEquals(
       q,
-      Right(Set(1)),
+      Right(Set(2)),
     )
   }
 
@@ -58,13 +58,13 @@ class PositionalIndexSearcherSuite extends munit.FunSuite {
     val q = search("the AND fast AND cat")
     assertEquals(
       q,
-      Right(Set(1)),
+      Right(Set(2)),
     )
   }
 
   test("Or") {
     val q = search("fast OR cat")
-    val results = Set(0, 1, 2)
+    val results = Set(1, 2, 3)
     assertEquals(
       q,
       Right(results),
@@ -73,7 +73,7 @@ class PositionalIndexSearcherSuite extends munit.FunSuite {
 
   test("Double Or") {
     val q = search("the OR fast OR cat")
-    val results = Set(0, 1, 2)
+    val results = Set(1, 2, 3)
     assertEquals(
       q,
       Right(results),
@@ -82,7 +82,7 @@ class PositionalIndexSearcherSuite extends munit.FunSuite {
 
   test("cat AND (fast OR quick)") {
     val q = search("cat AND (fast OR quick)")
-    val results = Set(0, 1)
+    val results = Set(1, 2)
     assertEquals(
       q,
       Right(results),
@@ -91,7 +91,7 @@ class PositionalIndexSearcherSuite extends munit.FunSuite {
 
   test("cat AND NOT fast") {
     val q = search("cat AND NOT fast")
-    val results = Set(0, 2)
+    val results = Set(1, 3)
     assertEquals(
       q,
       Right(results),
@@ -100,7 +100,7 @@ class PositionalIndexSearcherSuite extends munit.FunSuite {
 
   test("[a TO z]") {
     val q = search("[a TO z]")
-    val results = Set(0, 1, 2)
+    val results = Set(1, 2, 3)
     assertEquals(
       q,
       Right(results),
@@ -109,7 +109,7 @@ class PositionalIndexSearcherSuite extends munit.FunSuite {
 
   test("f*") {
     val q = search("f*")
-    val results = Set(0, 1)
+    val results = Set(1, 2)
     assertEquals(
       q,
       Right(results),
@@ -118,7 +118,7 @@ class PositionalIndexSearcherSuite extends munit.FunSuite {
 
   test("sleeps*") {
     val q = search("sleeps*")
-    val results = Set(2)
+    val results = Set(3)
     assertEquals(
       q,
       Right(results),
@@ -127,52 +127,52 @@ class PositionalIndexSearcherSuite extends munit.FunSuite {
 
   test("phrase, single word, start \"a\"") {
     val q = search("\"a\"")
-    assertEquals(q, Right(Set(2)))
+    assertEquals(q, Right(Set(3)))
   }
 
   test("phrase, single word, middle \"very\"") {
     val q = search("\"very\"")
-    assertEquals(q, Right(Set(1)))
+    assertEquals(q, Right(Set(2)))
   }
 
   test("phrase, single word, end \"day\"") {
     val q = search("\"day\"")
-    assertEquals(q, Right(Set(2)))
+    assertEquals(q, Right(Set(3)))
   }
 
   test("phrase, multi word, single match, start \"the quick brown\"") {
     val q = search("\"the quick brown\"")
-    assertEquals(q, Right(Set(0)))
+    assertEquals(q, Right(Set(1)))
   }
 
   test("phrase, multi word, single match, middle \"very fast\"") {
     val q = search("\"very fast\"")
-    assertEquals(q, Right(Set(1)))
+    assertEquals(q, Right(Set(2)))
   }
 
   test("phrase, multi word, single match, end \"sleeps all day\"") {
     val q = search("\"sleeps all day\"")
-    assertEquals(q, Right(Set(2)))
+    assertEquals(q, Right(Set(3)))
   }
 
   test("phrase, multi word(5), single match") {
     val q = search("\"the very fast cat jumped\"")
-    assertEquals(q, Right(Set(1)))
+    assertEquals(q, Right(Set(2)))
   }
 
   test("phrase, multi word(7), repeated words, single match") {
     val q = search("\"the very fast cat jumped across the\"")
-    assertEquals(q, Right(Set(1)))
+    assertEquals(q, Right(Set(2)))
   }
 
   test("phrase, all words, repeated words, single match") {
     val q = search("\"the very fast cat jumped across the room\"")
-    assertEquals(q, Right(Set(1)))
+    assertEquals(q, Right(Set(2)))
   }
 
   test("phrase, multi word, multi match \"lazy cat\"") {
     val q = search("\"lazy cat\"")
-    assertEquals(q, Right(Set(0, 2)))
+    assertEquals(q, Right(Set(1, 3)))
   }
 
   test("phrase, multi word, false match \"sleeps day\"") {
@@ -192,7 +192,7 @@ class PositionalIndexSearcherSuite extends munit.FunSuite {
 
   test("regex") {
     val q = search("/f(o|a)/")
-    val results = Set(0, 1)
+    val results = Set(1, 2)
     assertEquals(
       q,
       Right(results),

--- a/core/src/test/scala/pink/cozydev/protosearch/ScorerSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/ScorerSuite.scala
@@ -32,7 +32,7 @@ class ScorerSuite extends munit.FunSuite {
     )
     .fromList(allBooks)
 
-  val allDocs: Set[Int] = Range(0, allBooks.size).toSet
+  val allDocs: Set[Int] = Set(1, 2, 3, 4)
 
   val scorer = Scorer(index)
   def score(q: String, docs: Set[Int]): Either[String, List[(Int, Double)]] =
@@ -44,8 +44,8 @@ class ScorerSuite extends munit.FunSuite {
     hits.fold(_ => Nil, ds => ds.map(_._1))
 
   test("doc with matching term is ordered first") {
-    val hits = score("Bad", Set(1))
-    assertEquals(ordered(hits), List(1))
+    val hits = score("Bad", Set(2))
+    assertEquals(ordered(hits), List(2))
   }
 
   test("no results for docs without matching terms") {
@@ -55,35 +55,35 @@ class ScorerSuite extends munit.FunSuite {
 
   test("docs with multiple matches score higher") {
     val hits = score("Tale OR Two", allDocs)
-    assertEquals(ordered(hits), List(1, 0, 2))
+    assertEquals(ordered(hits), List(2, 1, 3))
   }
 
   test("additional matching queries increases score") {
-    val sc1 = score("Tale OR Two", Set(2)).map(_.head._2)
-    val sc2 = score("author:Seuss Tale OR Two", Set(2)).map(_.head._2)
+    val sc1 = score("Tale OR Two", Set(3)).map(_.head._2)
+    val sc2 = score("author:Seuss Tale OR Two", Set(3)).map(_.head._2)
     assert(sc1.exists(s1 => sc2.exists(s2 => s2 > s1)))
   }
 
   test("scores prefix queries") {
     val hits = score("T*", allDocs)
-    assertEquals(ordered(hits), List(1, 0, 2))
+    assertEquals(ordered(hits), List(2, 1, 3))
   }
 
   test("scores phrase query") {
     val hits = score("\"Two Bad Mice\"", allDocs)
-    assertEquals(ordered(hits), List(1))
+    assertEquals(ordered(hits), List(2))
   }
 
   test("scorer with topN=1 returns only top doc") {
     val q = "Tale OR Two" // has 3 matches
     val hits = QueryParser.parse(q).flatMap(q => scorer.score(q, allDocs, topN = 1))
-    assertEquals(ordered(hits), List(1))
+    assertEquals(ordered(hits), List(2))
   }
 
   test("scorer topN can be bigger than number of matches") {
     val q = "Tale OR Two" // has 3 matches
     val hits = QueryParser.parse(q).flatMap(q => scorer.score(q, allDocs, topN = 999))
-    assertEquals(ordered(hits), List(1, 0, 2))
+    assertEquals(ordered(hits), List(2, 1, 3))
   }
 
 }

--- a/core/src/test/scala/pink/cozydev/protosearch/SearcherSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/SearcherSuite.scala
@@ -37,7 +37,7 @@ class SearcherSuite extends munit.FunSuite {
   def search(q: String): Either[String, List[Book]] = {
     val req = SearchRequest.default(q)
     val result = searcher.search(req)
-    result.toEither.map(hits => hits.map(h => allBooks(h.id)))
+    result.toEither.map(hits => hits.map(h => allBooks(h.id - 1)))
   }
 
   def searchHit(q: String): Either[String, List[(Int, Map[String, String])]] = {
@@ -52,7 +52,7 @@ class SearcherSuite extends munit.FunSuite {
       "title" -> "The Tale of Two Bad Mice",
       "author" -> "Beatrix Potter",
     )
-    assertEquals(books, Right(List(1 -> miceMap)))
+    assertEquals(books, Right(List(2 -> miceMap)))
   }
 
   test("Term") {

--- a/core/src/test/scala/pink/cozydev/protosearch/WriteReadLoopSuite.scala
+++ b/core/src/test/scala/pink/cozydev/protosearch/WriteReadLoopSuite.scala
@@ -38,7 +38,7 @@ class WriteReadLoopSuite extends munit.FunSuite {
       val searcher = Searcher.default(index)
       val req = SearchRequest.default(qs)
       val result = searcher.search(req)
-      result.toEither.map(hits => hits.map(h => allBooks(h.id)))
+      result.toEither.map(hits => hits.map(h => allBooks(h.id - 1)))
     }
 
     val indexRead = indexBytes

--- a/docs/02-tutorial/02-querying.md
+++ b/docs/02-tutorial/02-querying.md
@@ -40,7 +40,10 @@ def search(q: String): List[Book] = {
   val req = SearchRequest.default(q)
   searcher.search(req) match {
     case SearchFailure(_) => Nil
-    case SearchSuccess(hits) => hits.map(h => books(h.id))
+    case SearchSuccess(hits) => hits.map(h =>
+      // docIds start at 1 not 0
+      books(h.id - 1)
+    )
   }
 }
 ```


### PR DESCRIPTION
This PR changes how we assign docIds while creating an index, such that they now start at 1 instead of 0.
This allows us to use `currentDocId = 0` as a starting state on postings iterators, which is useful to distinguish it from the exhausted state `-1` or the matching document 1 state, `1`